### PR TITLE
Add dynamic critic counts and confirmation tracking

### DIFF
--- a/lib/app_state.dart
+++ b/lib/app_state.dart
@@ -310,6 +310,12 @@ class FFAppState extends ChangeNotifier {
     prefs.setBool('ff_navOpen', value);
   }
 
+  bool _shouldRefreshCriticCounts = false;
+  bool get shouldRefreshCriticCounts => _shouldRefreshCriticCounts;
+  set shouldRefreshCriticCounts(bool value) {
+    _shouldRefreshCriticCounts = value;
+  }
+
   String _professorNameSelected = '교수님';
   String get professorNameSelected => _professorNameSelected;
   set professorNameSelected(String value) {

--- a/lib/pages/professor/submissions/prof_subject_portpolio/prof_subject_portpolio_widget.dart
+++ b/lib/pages/professor/submissions/prof_subject_portpolio/prof_subject_portpolio_widget.dart
@@ -1574,6 +1574,7 @@ class _ProfSubjectPortpolioWidgetState
                                                                                                   await SubjectportpolioTable().update(
                                                                                                     data: {
                                                                                                       'critic_html': _model.textController1.text,
+                                                                                                      'portpolioresult': '미확인',
                                                                                                     },
                                                                                                     matchingRows: (rows) => rows
                                                                                                         .eqOrNull(
@@ -1589,6 +1590,9 @@ class _ProfSubjectPortpolioWidgetState
                                                                                                           _model.weeks,
                                                                                                         ),
                                                                                                   );
+                                                                                                  FFAppState().update(() {
+                                                                                                    FFAppState().shouldRefreshCriticCounts = true;
+                                                                                                  });
                                                                                                   await showDialog(
                                                                                                     context: context,
                                                                                                     builder: (alertDialogContext) {
@@ -3351,6 +3355,7 @@ class _ProfSubjectPortpolioWidgetState
                                                                                                   await SubjectportpolioTable().update(
                                                                                                     data: {
                                                                                                       'critic_html': _model.textController2.text,
+                                                                                                      'portpolioresult': '미확인',
                                                                                                     },
                                                                                                     matchingRows: (rows) => rows
                                                                                                         .eqOrNull(
@@ -3366,6 +3371,9 @@ class _ProfSubjectPortpolioWidgetState
                                                                                                           _model.weeks,
                                                                                                         ),
                                                                                                   );
+                                                                                                  FFAppState().update(() {
+                                                                                                    FFAppState().shouldRefreshCriticCounts = true;
+                                                                                                  });
                                                                                                   await showDialog(
                                                                                                     context: context,
                                                                                                     builder: (alertDialogContext) {

--- a/lib/pages/student/submissions/student_subject_portpolio/student_subject_portpolio_widget.dart
+++ b/lib/pages/student/submissions/student_subject_portpolio/student_subject_portpolio_widget.dart
@@ -40,6 +40,41 @@ class _StudentSubjectPortpolioWidgetState
 
   final animationsMap = <String, AnimationInfo>{};
 
+  Future<void> _markCriticAsConfirmed(String? week) async {
+    if (week == null) {
+      return;
+    }
+    final currentCritic = _model.sPortpolioList
+        .where((e) => e.week == week)
+        .toList()
+        .firstOrNull;
+    if (currentCritic == null) {
+      return;
+    }
+    final criticContent = currentCritic.criticHtml ?? '';
+    if (criticContent.trim().isEmpty || criticContent.trim() == '크리틱 내용') {
+      return;
+    }
+    if ((currentCritic.portpolioresult ?? '').trim() == '확인') {
+      return;
+    }
+    await SubjectportpolioTable().update(
+      data: {
+        'portpolioresult': '확인',
+      },
+      matchingRows: (rows) => rows.eqOrNull(
+        'id',
+        currentCritic.id,
+      ),
+    );
+    final index =
+        _model.sPortpolioList.indexWhere((e) => e.id == currentCritic.id);
+    if (index != -1) {
+      _model.sPortpolioList[index].portpolioresult = '확인';
+    }
+    safeSetState(() {});
+  }
+
   @override
   void initState() {
     super.initState();
@@ -493,11 +528,15 @@ class _StudentSubjectPortpolioWidgetState
                                                                                       focusColor: Colors.transparent,
                                                                                       hoverColor: Colors.transparent,
                                                                                       highlightColor: Colors.transparent,
-                                                                                      onTap: () async {
-                                                                                        _model.weeks = '${_model.sliderValue1?.toString()}주차';
-                                                                                        _model.openOrHideButton = !_model.openOrHideButton;
-                                                                                        safeSetState(() {});
-                                                                                      },
+                                                                                        onTap: () async {
+                                                                                          _model.weeks = '${_model.sliderValue1?.toString()}주차';
+                                                                                          final newOpenState = !_model.openOrHideButton;
+                                                                                          _model.openOrHideButton = newOpenState;
+                                                                                          safeSetState(() {});
+                                                                                          if (newOpenState) {
+                                                                                            await _markCriticAsConfirmed(_model.weeks);
+                                                                                          }
+                                                                                        },
                                                                                       child: Icon(
                                                                                         Icons.expand_more,
                                                                                         color: valueOrDefault<Color>(
@@ -2551,16 +2590,20 @@ class _StudentSubjectPortpolioWidgetState
                                                                                   focusColor: Colors.transparent,
                                                                                   hoverColor: Colors.transparent,
                                                                                   highlightColor: Colors.transparent,
-                                                                                  onTap: () async {
-                                                                                    _model.weeks = '${_model.sliderValue2?.toString()}주차';
-                                                                                    _model.openOrHideButton = !_model.openOrHideButton;
-                                                                                    safeSetState(() {});
-                                                                                    _model.weekoutputMobile = await WeeksUploadTable().queryRows(
-                                                                                      queryFn: (q) => q.eqOrNull(
-                                                                                        'weeks_name',
-                                                                                        _model.weeks,
-                                                                                      ),
-                                                                                    );
+                                                                                    onTap: () async {
+                                                                                      _model.weeks = '${_model.sliderValue2?.toString()}주차';
+                                                                                      final newOpenState = !_model.openOrHideButton;
+                                                                                      _model.openOrHideButton = newOpenState;
+                                                                                      safeSetState(() {});
+                                                                                      if (newOpenState) {
+                                                                                        await _markCriticAsConfirmed(_model.weeks);
+                                                                                      }
+                                                                                      _model.weekoutputMobile = await WeeksUploadTable().queryRows(
+                                                                                        queryFn: (q) => q.eqOrNull(
+                                                                                          'weeks_name',
+                                                                                          _model.weeks,
+                                                                                        ),
+                                                                                      );
 
                                                                                     safeSetState(() {});
                                                                                   },


### PR DESCRIPTION
## Summary
- pull professor critique data from Supabase to show dynamic written and confirmed counts in the shared left panel
- reset critique confirmation whenever professors update comments and mark them as confirmed when students open the feedback
- add shared app state flag so pages can request refreshed critic totals after updates

## Testing
- not run (flutter tooling not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68ce099f1e888323a792fa16b92c323b