### PR TITLE
Add critic count tracking and refresh hooks

### DIFF
--- a/lib/backend/supabase/database/tables/subjectportpolio.dart
+++ b/lib/backend/supabase/database/tables/subjectportpolio.dart
@@ -51,4 +51,9 @@ class SubjectportpolioRow extends SupabaseDataRow {
 
   int? get grade => getField<int>('grade');
   set grade(int? value) => setField<int>('grade', value);
+
+  DateTime? get criticConfirmedAt =>
+      getField<DateTime>('critic_confirmed_at');
+  set criticConfirmedAt(DateTime? value) =>
+      setField<DateTime>('critic_confirmed_at', value);
 }

--- a/lib/components/default_layout/left_right/left_widget/left_widget_model.dart
+++ b/lib/components/default_layout/left_right/left_widget/left_widget_model.dart
@@ -15,7 +15,9 @@ class LeftWidgetModel extends FlutterFlowModel<LeftWidgetWidget> {
   bool mouseRegionHovered4 = false;
 
   @override
-  void initState(BuildContext context) {}
+  void initState(BuildContext context) {
+    FFAppState().refreshCriticCounters();
+  }
 
   @override
   void dispose() {}

--- a/lib/components/default_layout/left_right/left_widget/left_widget_widget.dart
+++ b/lib/components/default_layout/left_right/left_widget/left_widget_widget.dart
@@ -879,10 +879,15 @@ class _LeftWidgetWidgetState extends State<LeftWidgetWidget> {
                                                                             5.0,
                                                                             0.0),
                                                                 child: Text(
-                                                                  FFLocalizations.of(
-                                                                          context)
-                                                                      .getText(
-                                                                    'cmmeitxn' /* - */,
+                                                                  formatNumber(
+                                                                    FFAppState()
+                                                                        .writtenCriticCount,
+                                                                    formatType:
+                                                                        FormatType
+                                                                            .decimal,
+                                                                    decimalType:
+                                                                        DecimalType
+                                                                            .automatic,
                                                                   ),
                                                                   style: FlutterFlowTheme.of(
                                                                           context)
@@ -1031,10 +1036,15 @@ class _LeftWidgetWidgetState extends State<LeftWidgetWidget> {
                                                                             5.0,
                                                                             0.0),
                                                                 child: Text(
-                                                                  FFLocalizations.of(
-                                                                          context)
-                                                                      .getText(
-                                                                    '0hvfh7ub' /* - */,
+                                                                  formatNumber(
+                                                                    FFAppState()
+                                                                        .confirmedCriticCount,
+                                                                    formatType:
+                                                                        FormatType
+                                                                            .decimal,
+                                                                    decimalType:
+                                                                        DecimalType
+                                                                            .automatic,
                                                                   ),
                                                                   style: FlutterFlowTheme.of(
                                                                           context)

--- a/lib/pages/professor/submissions/prof_subject_portpolio/prof_subject_portpolio_widget.dart
+++ b/lib/pages/professor/submissions/prof_subject_portpolio/prof_subject_portpolio_widget.dart
@@ -576,15 +576,17 @@ class _ProfSubjectPortpolioWidgetState
                                                                               hoverColor: Colors.transparent,
                                                                               highlightColor: Colors.transparent,
                                                                                  onTap: () async {
-                                                                                   _model.openOrHideButton = !_model.openOrHideButton;
-                                                                                   _model.weeks = '${_model.sliderValue1?.toString()}주차';
-                                                                                   safeSetState(() {});
-                                                                                   _model.nameClickednum = -1;
-                                                                                   _model.nameselectforquery = null;
-                                                                                    _model.sPortpolioList =
-                                                                                        _model.fullSPortpolioList.toList();
-                                                                                    safeSetState(() {});
-                                                                                 },
+                                                                                _model.openOrHideButton =
+                                                                                    !_model.openOrHideButton;
+                                                                                _model.weeks =
+                                                                                    '${_model.sliderValue1?.toString()}주차';
+                                                                                safeSetState(() {});
+                                                                                _model.nameClickednum = -1;
+                                                                                _model.nameselectforquery = null;
+                                                                                _model.sPortpolioList =
+                                                                                    _model.fullSPortpolioList.toList();
+                                                                                safeSetState(() {});
+                                                                              },
                                                                               child: Icon(
                                                                                 Icons.expand_more,
                                                                                 color: Color(0xFF284E75),
@@ -1594,6 +1596,8 @@ class _ProfSubjectPortpolioWidgetState
                                                                                                   );
 
                                                                                                   safeSetState(() {});
+                                                                                                  await FFAppState()
+                                                                                                      .refreshCriticCounters();
                                                                                                 },
                                                                                                 text: FFLocalizations.of(context).getText(
                                                                                                   'hnnsauoe' /* 수정 */,
@@ -3245,6 +3249,8 @@ class _ProfSubjectPortpolioWidgetState
                                                                                                   );
 
                                                                                                   safeSetState(() {});
+                                                                                                  await FFAppState()
+                                                                                                      .refreshCriticCounters();
                                                                                                 },
                                                                                                 text: FFLocalizations.of(context).getText(
                                                                                                   '0oqzslbq' /* 수정 */,


### PR DESCRIPTION
## Summary
- add persisted critic counter fields in app state with a refresh helper that queries subject portfolios
- extend the left sidebar model and widget to load and display the live critic counts
- refresh the critic counters after professor critique updates and expose the new confirmation timestamp on the table row

## Testing
- not run (Flutter/Dart CLI unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68cf4bbb2ab08323b330c8e0c873af69