### PR TITLE
Sync student critic counts with Supabase data

### DIFF
--- a/lib/components/default_layout/left_right/student_left_widget/student_left_widget_widget.dart
+++ b/lib/components/default_layout/left_right/student_left_widget/student_left_widget_widget.dart
@@ -1,3 +1,4 @@
+import '/backend/supabase/supabase.dart';
 import '/flutter_flow/flutter_flow_theme.dart';
 import '/flutter_flow/flutter_flow_util.dart';
 import '/custom_code/widgets/index.dart' as custom_widgets;
@@ -17,6 +18,8 @@ class StudentLeftWidgetWidget extends StatefulWidget {
 
 class _StudentLeftWidgetWidgetState extends State<StudentLeftWidgetWidget> {
   late StudentLeftWidgetModel _model;
+  Future<int>? _registeredCriticCountFuture;
+  String? _registeredCriticCountKey;
 
   @override
   void setState(VoidCallback callback) {
@@ -30,6 +33,80 @@ class _StudentLeftWidgetWidgetState extends State<StudentLeftWidgetWidget> {
     _model = createModel(context, () => StudentLeftWidgetModel());
 
     WidgetsBinding.instance.addPostFrameCallback((_) => safeSetState(() {}));
+  }
+
+  Future<int> _fetchRegisteredCriticCount({
+    required int classId,
+    required String studentName,
+  }) async {
+    if (classId == 0 || studentName.isEmpty) {
+      return 0;
+    }
+
+    try {
+      final rows = await SubjectportpolioTable().queryRows(
+        queryFn: (q) => q
+            .eqOrNull('class', classId)
+            .eqOrNull('student_name', studentName),
+      );
+
+      return rows
+          .where((row) {
+            final url = row.url?.trim() ?? '';
+            final result = row.portpolioresult?.trim() ?? '';
+            final title = row.title?.trim() ?? '';
+            return url.isNotEmpty || result.isNotEmpty || title.isNotEmpty;
+          })
+          .length;
+    } catch (e) {
+      print('Error loading registered critic count: $e');
+      return 0;
+    }
+  }
+
+  Future<int> _ensureRegisteredCriticCountFuture() {
+    final appState = FFAppState();
+    final queryKey = [
+      appState.classSelectedID,
+      appState.studentNameSelected,
+      appState.studentPortporlioAfterEditor,
+      appState.studentPortporlioDeleteClicked,
+    ].join('|');
+
+    if (_registeredCriticCountFuture == null ||
+        _registeredCriticCountKey != queryKey) {
+      _registeredCriticCountKey = queryKey;
+      _registeredCriticCountFuture = _fetchRegisteredCriticCount(
+        classId: appState.classSelectedID,
+        studentName: appState.studentNameSelected,
+      );
+    }
+
+    return _registeredCriticCountFuture!;
+  }
+
+  TextStyle _registeredCriticCountTextStyle(BuildContext context) {
+    return FlutterFlowTheme.of(context).bodyMedium.override(
+          font: GoogleFonts.openSans(
+            fontWeight: FlutterFlowTheme.of(context).bodyMedium.fontWeight,
+            fontStyle: FlutterFlowTheme.of(context).bodyMedium.fontStyle,
+          ),
+          color: FlutterFlowTheme.of(context).primaryText,
+          fontSize: () {
+            if (MediaQuery.sizeOf(context).width < kBreakpointSmall) {
+              return 12.0;
+            } else if (MediaQuery.sizeOf(context).width < kBreakpointMedium) {
+              return 10.0;
+            } else if (MediaQuery.sizeOf(context).width < kBreakpointLarge) {
+              return 10.0;
+            } else {
+              return 12.0;
+            }
+          }(),
+          letterSpacing: 0.0,
+          fontWeight: FlutterFlowTheme.of(context).bodyMedium.fontWeight,
+          fontStyle: FlutterFlowTheme.of(context).bodyMedium.fontStyle,
+        );
   }
 
   @override
@@ -868,51 +945,59 @@ class _StudentLeftWidgetWidgetState extends State<StudentLeftWidgetWidget> {
                                                                             0.0,
                                                                             5.0,
                                                                             0.0),
-                                                                child: Text(
-                                                                  FFLocalizations.of(
-                                                                          context)
-                                                                      .getText(
-                                                                    '1urtnl98' /* - */,
-                                                                  ),
-                                                                  style: FlutterFlowTheme.of(
-                                                                          context)
-                                                                      .bodyMedium
-                                                                      .override(
-                                                                        font: GoogleFonts
-                                                                            .openSans(
-                                                                          fontWeight: FlutterFlowTheme.of(context)
-                                                                              .bodyMedium
-                                                                              .fontWeight,
-                                                                          fontStyle: FlutterFlowTheme.of(context)
-                                                                              .bodyMedium
-                                                                              .fontStyle,
+                                                                child:
+                                                                    FutureBuilder<int>(
+                                                                  future:
+                                                                      _ensureRegisteredCriticCountFuture(),
+                                                                  builder: (context,
+                                                                      snapshot) {
+                                                                    if (snapshot
+                                                                            .connectionState ==
+                                                                        ConnectionState
+                                                                            .waiting) {
+                                                                      return Text(
+                                                                        FFLocalizations.of(
+                                                                                context)
+                                                                            .getText(
+                                                                          '1urtnl98' /* - */,
                                                                         ),
-                                                                        color: FlutterFlowTheme.of(context)
-                                                                            .primaryText,
-                                                                        fontSize:
-                                                                            () {
-                                                                          if (MediaQuery.sizeOf(context).width <
-                                                                              kBreakpointSmall) {
-                                                                            return 12.0;
-                                                                          } else if (MediaQuery.sizeOf(context).width <
-                                                                              kBreakpointMedium) {
-                                                                            return 10.0;
-                                                                          } else if (MediaQuery.sizeOf(context).width <
-                                                                              kBreakpointLarge) {
-                                                                            return 10.0;
-                                                                          } else {
-                                                                            return 12.0;
-                                                                          }
-                                                                        }(),
-                                                                        letterSpacing:
-                                                                            0.0,
-                                                                        fontWeight: FlutterFlowTheme.of(context)
-                                                                            .bodyMedium
-                                                                            .fontWeight,
-                                                                        fontStyle: FlutterFlowTheme.of(context)
-                                                                            .bodyMedium
-                                                                            .fontStyle,
+                                                                        style:
+                                                                            _registeredCriticCountTextStyle(context),
+                                                                      );
+                                                                    }
+
+                                                                    if (snapshot
+                                                                            .hasError ||
+                                                                        !snapshot
+                                                                            .hasData) {
+                                                                      return Text(
+                                                                        FFLocalizations.of(
+                                                                                context)
+                                                                            .getText(
+                                                                          '1urtnl98' /* - */,
+                                                                        ),
+                                                                        style:
+                                                                            _registeredCriticCountTextStyle(context),
+                                                                      );
+                                                                    }
+
+                                                                    final count =
+                                                                        snapshot
+                                                                            .data!;
+                                                                    return Text(
+                                                                      formatNumber(
+                                                                        count,
+                                                                        formatType:
+                                                                            FormatType
+                                                                                .decimal,
+                                                                        decimalType:
+                                                                            DecimalType
+                                                                                .automatic,
                                                                       ),
+                                                                      style:
+                                                                          _registeredCriticCountTextStyle(context),
+                                                                    );
+                                                                  },
                                                                 ),
                                                               ),
                                                             ),

--- a/lib/pages/student/submissions/student_subject_portpolio/student_subject_portpolio_widget.dart
+++ b/lib/pages/student/submissions/student_subject_portpolio/student_subject_portpolio_widget.dart
@@ -40,6 +40,47 @@ class _StudentSubjectPortpolioWidgetState
 
   final animationsMap = <String, AnimationInfo>{};
 
+  Future<void> _confirmCriticForWeek(String? week) async {
+    final effectiveWeek = week?.trim();
+    if (effectiveWeek == null || effectiveWeek.isEmpty) {
+      return;
+    }
+
+    final matchingRow = _model.sPortpolioList
+        .where((row) => (row.week ?? '').trim() == effectiveWeek)
+        .toList()
+        .firstOrNull;
+
+    if (matchingRow == null) {
+      return;
+    }
+
+    final criticHtml = matchingRow.criticHtml?.trim() ?? '';
+    if (criticHtml.isEmpty) {
+      return;
+    }
+
+    if (matchingRow.criticConfirmedAt != null) {
+      return;
+    }
+
+    final now = DateTime.now().toUtc();
+    try {
+      await SubjectportpolioTable().update(
+        data: {
+          'critic_confirmed_at': now,
+        },
+        matchingRows: (rows) => rows.eq('id', matchingRow.id),
+      );
+
+      matchingRow.criticConfirmedAt = now;
+      await FFAppState().refreshCriticCounters();
+      safeSetState(() {});
+    } catch (e) {
+      print('Error confirming critic for week $effectiveWeek: $e');
+    }
+  }
+
   @override
   void initState() {
     super.initState();
@@ -77,6 +118,7 @@ class _StudentSubjectPortpolioWidgetState
       _model.sPortpolioList =
           _model.onloadportpoliooutput!.toList().cast<SubjectportpolioRow>();
       safeSetState(() {});
+      await _confirmCriticForWeek(_model.weeks);
     });
 
     _model.textController1 ??= TextEditingController();
@@ -497,6 +539,8 @@ class _StudentSubjectPortpolioWidgetState
                                                                                         _model.weeks = '${_model.sliderValue1?.toString()}주차';
                                                                                         _model.openOrHideButton = !_model.openOrHideButton;
                                                                                         safeSetState(() {});
+                                                                                        await _confirmCriticForWeek(
+                                                                                            _model.weeks);
                                                                                       },
                                                                                       child: Icon(
                                                                                         Icons.expand_more,
@@ -2555,6 +2599,8 @@ class _StudentSubjectPortpolioWidgetState
                                                                                     _model.weeks = '${_model.sliderValue2?.toString()}주차';
                                                                                     _model.openOrHideButton = !_model.openOrHideButton;
                                                                                     safeSetState(() {});
+                                                                                    await _confirmCriticForWeek(
+                                                                                        _model.weeks);
                                                                                     _model.weekoutputMobile = await WeeksUploadTable().queryRows(
                                                                                       queryFn: (q) => q.eqOrNull(
                                                                                         'weeks_name',


### PR DESCRIPTION
## Summary
- display the registered-critic total on the student left panel by querying the subject portfolio rows for the current student/class
- reuse the fetched row data to count only entries with real content so the badge matches the uploaded weekly materials
- refresh the shared critic counters after a student confirms a critique so the professor view can show the updated confirmation total

## Testing
- Not run (flutter tooling is unavailable in the container)

------
https://chatgpt.com/codex/tasks/task_e_68cf67d35e9483239cdfc92abf0848fa