### PR TITLE
Add core theme constants and responsive wrapper utilities

### DIFF
--- a/lib/core/app_theme.dart
+++ b/lib/core/app_theme.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+
+class AppTheme {
+  static const double fontSize1 = 22.0;
+  static const double fontSize2 = 18.0;
+  static const double fontSize3 = 16.0;
+  static const double fontSize4 = 12.0;
+
+  static TextStyle get headline1 => const TextStyle(
+        fontSize: fontSize1,
+        fontWeight: FontWeight.bold,
+        overflow: TextOverflow.ellipsis,
+      );
+
+  static TextStyle get headline2 => const TextStyle(
+        fontSize: fontSize2,
+        fontWeight: FontWeight.w600,
+        overflow: TextOverflow.ellipsis,
+      );
+
+  static TextStyle get bodyText1 => const TextStyle(
+        fontSize: fontSize3,
+        overflow: TextOverflow.ellipsis,
+      );
+
+  static TextStyle get caption => TextStyle(
+        fontSize: fontSize4,
+        color: Colors.grey.shade600,
+        overflow: TextOverflow.ellipsis,
+      );
+}

--- a/lib/core/responsive_wrapper.dart
+++ b/lib/core/responsive_wrapper.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/material.dart';
+
+class ResponsiveWrapper extends StatelessWidget {
+  const ResponsiveWrapper({
+    super.key,
+    required this.child,
+    this.minWidth = 1200,
+  });
+
+  final Widget child;
+  final double minWidth;
+
+  @override
+  Widget build(BuildContext context) {
+    final size = MediaQuery.of(context).size;
+    if (size.width < 600) {
+      return child;
+    }
+
+    return Scrollbar(
+      thumbVisibility: true,
+      child: SingleChildScrollView(
+        scrollDirection: Axis.horizontal,
+        child: ConstrainedBox(
+          constraints: BoxConstraints(
+            minWidth: minWidth,
+            minHeight: size.height,
+          ),
+          child: SingleChildScrollView(
+            child: SizedBox(
+              width: minWidth,
+              child: child,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -5,6 +5,9 @@ import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_web_plugins/url_strategy.dart';
 
+import 'package:archiverse/core/app_theme.dart';
+import 'package:archiverse/core/responsive_wrapper.dart';
+
 import 'auth/supabase_auth/supabase_user_provider.dart';
 import 'auth/supabase_auth/auth_util.dart';
 
@@ -114,8 +117,20 @@ class _MyAppState extends State<MyApp> {
       theme: ThemeData(
         brightness: Brightness.light,
         useMaterial3: false,
+        textTheme: TextTheme(
+          displayLarge: AppTheme.headline1,
+          displayMedium: AppTheme.headline2,
+          bodyLarge: AppTheme.bodyText1,
+          bodyMedium: AppTheme.caption,
+        ),
       ),
       themeMode: _themeMode,
+      builder: (context, child) {
+        if (child == null) {
+          return const SizedBox.shrink();
+        }
+        return ResponsiveWrapper(child: child);
+      },
       routerConfig: _router,
     );
   }


### PR DESCRIPTION
## Summary
- add a reusable `AppTheme` class that centralizes the four standard font sizes and text styles
- introduce a `ResponsiveWrapper` widget that enforces a scrollable fixed-width layout for large screens while leaving mobile untouched
- wire the new utilities into `MaterialApp` so text themes pick up the shared styles and every route is wrapped by the responsive container

## Testing
- `flutter clean` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68d0a34b94f483239b1754e27d12cfed