### PR TITLE
Adjust admin nav highlighting and admin overrides

### DIFF
--- a/lib/backend/supabase/database/tables/admin_post.dart
+++ b/lib/backend/supabase/database/tables/admin_post.dart
@@ -25,4 +25,13 @@ class AdminPostRow extends SupabaseDataRow {
 
   String get adminInfo => getField<String>('AdminInfo')!;
   set adminInfo(String value) => setField<String>('AdminInfo', value);
+
+  String? get name => getField<String>('name');
+  set name(String? value) => setField<String>('name', value);
+
+  int? get userType => getField<int>('user_type');
+  set userType(int? value) => setField<int>('user_type', value);
+
+  String get role => getField<String>('role')!;
+  set role(String value) => setField<String>('role', value);
 }

--- a/lib/backend/supabase/database/tables/class.dart
+++ b/lib/backend/supabase/database/tables/class.dart
@@ -26,6 +26,9 @@ class ClassRow extends SupabaseDataRow {
   String? get professor => getField<String>('professor');
   set professor(String? value) => setField<String>('professor', value);
 
+  int? get professorId => getField<int>('professor_id');
+  set professorId(int? value) => setField<int>('professor_id', value);
+
   String? get year => getField<String>('year');
   set year(String? value) => setField<String>('year', value);
 

--- a/lib/backend/supabase/database/tables/posts.dart
+++ b/lib/backend/supabase/database/tables/posts.dart
@@ -17,24 +17,25 @@ class PostsRow extends SupabaseDataRow {
   int get id => getField<int>('id')!;
   set id(int value) => setField<int>('id', value);
 
-  DateTime get createdAt => getField<DateTime>('created_at')!;
-  set createdAt(DateTime value) => setField<DateTime>('created_at', value);
+  String? get name => getField<String>('name');
+  set name(String? value) => setField<String>('name', value);
 
-  String? get user => getField<String>('user');
-  set user(String? value) => setField<String>('user', value);
+  String? get position => getField<String>('position');
+  set position(String? value) => setField<String>('position', value);
+
+  String? get email => getField<String>('email');
+  set email(String? value) => setField<String>('email', value);
+
+  String? get phone => getField<String>('phone');
+  set phone(String? value) => setField<String>('phone', value);
+
+  int? get permissionLevel => getField<int>('permission_level');
+  set permissionLevel(int? value) =>
+      setField<int>('permission_level', value);
 
   int? get userType => getField<int>('user_type');
   set userType(int? value) => setField<int>('user_type', value);
 
-  String? get userAlias => getField<String>('user_alias');
-  set userAlias(String? value) => setField<String>('user_alias', value);
-
-  String? get userEmail => getField<String>('user_email');
-  set userEmail(String? value) => setField<String>('user_email', value);
-
-  String? get university => getField<String>('university');
-  set university(String? value) => setField<String>('university', value);
-
-  String? get name => getField<String>('name');
-  set name(String? value) => setField<String>('name', value);
+  DateTime? get createdAt => getField<DateTime>('created_at');
+  set createdAt(DateTime? value) => setField<DateTime>('created_at', value);
 }

--- a/lib/backend/supabase/supabase.dart
+++ b/lib/backend/supabase/supabase.dart
@@ -27,3 +27,4 @@ class SupaFlow {
             FlutterAuthClientOptions(authFlowType: AuthFlowType.implicit),
       );
 }
+

--- a/lib/components/account_manage/account_manage_row/account_manage_row_model.dart
+++ b/lib/components/account_manage/account_manage_row/account_manage_row_model.dart
@@ -13,9 +13,31 @@ class AccountManageRowModel extends FlutterFlowModel<AccountManageRowWidget> {
   String? dropDownValue2;
   FormFieldController<String>? dropDownValueController2;
 
-  @override
-  void initState(BuildContext context) {}
+  bool isEditing = false;
+
+  Map<String, dynamic> editedData = {};
+
+  FocusNode? nameFocusNode;
+
+  TextEditingController? nameTextController;
+
+  FocusNode? phoneFocusNode;
+
+  TextEditingController? phoneTextController;
+
+  bool isSaving = false;
 
   @override
-  void dispose() {}
+  void initState(BuildContext context) {
+    nameFocusNode = FocusNode();
+    phoneFocusNode = FocusNode();
+  }
+
+  @override
+  void dispose() {
+    nameFocusNode?.dispose();
+    nameTextController?.dispose();
+    phoneFocusNode?.dispose();
+    phoneTextController?.dispose();
+  }
 }

--- a/lib/components/account_manage/account_manage_row/account_manage_row_widget.dart
+++ b/lib/components/account_manage/account_manage_row/account_manage_row_widget.dart
@@ -1,3 +1,4 @@
+import '/backend/supabase/supabase.dart';
 import '/flutter_flow/flutter_flow_drop_down.dart';
 import '/flutter_flow/flutter_flow_theme.dart';
 import '/flutter_flow/flutter_flow_util.dart';
@@ -11,27 +12,15 @@ export 'account_manage_row_model.dart';
 class AccountManageRowWidget extends StatefulWidget {
   const AccountManageRowWidget({
     super.key,
-    String? professorName,
-    String? professorRole,
-    String? professorEmail,
-    String? professorContact,
-    String? professorAuthority,
+    required this.post,
     this.confirmEdit,
-    bool? isEditing,
-  })  : this.professorName = professorName ?? '홍길동',
-        this.professorRole = professorRole ?? 'PD교수',
-        this.professorEmail = professorEmail ?? 'professor@schd.co.kr',
-        this.professorContact = professorContact ?? '010-1234-5678',
-        this.professorAuthority = professorAuthority ?? '마스터',
-        this.isEditing = isEditing ?? false;
+    this.onSelected,
+  });
 
-  final String professorName;
-  final String professorRole;
-  final String professorEmail;
-  final String professorContact;
-  final String professorAuthority;
-  final Future Function(bool confirm)? confirmEdit;
-  final bool isEditing;
+  final PostsRow post;
+  final Future<void> Function(bool confirm, Map<String, dynamic> updatedData)?
+      confirmEdit;
+  final VoidCallback? onSelected;
 
   @override
   State<AccountManageRowWidget> createState() => _AccountManageRowWidgetState();
@@ -39,6 +28,7 @@ class AccountManageRowWidget extends StatefulWidget {
 
 class _AccountManageRowWidgetState extends State<AccountManageRowWidget> {
   late AccountManageRowModel _model;
+  bool _hasInitializedLocalizedValues = false;
 
   @override
   void setState(VoidCallback callback) {
@@ -50,245 +40,433 @@ class _AccountManageRowWidgetState extends State<AccountManageRowWidget> {
   void initState() {
     super.initState();
     _model = createModel(context, () => AccountManageRowModel());
+    _model.nameTextController ??=
+        TextEditingController(text: widget.post.name ?? '');
+    _model.phoneTextController ??=
+        TextEditingController(text: widget.post.phone ?? '');
+    final initialUserTypeLabel = _userTypeLabel(widget.post.userType);
+    _model.dropDownValue1 = initialUserTypeLabel;
+    _model.dropDownValueController1 =
+        FormFieldController<String>(initialUserTypeLabel);
 
     WidgetsBinding.instance.addPostFrameCallback((_) => safeSetState(() {}));
   }
 
   @override
-  void dispose() {
-    _model.maybeDispose();
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    if (_hasInitializedLocalizedValues) {
+      return;
+    }
+    final permissionLabel =
+        _permissionLabelFromLevel(widget.post.permissionLevel ?? 1);
+    _model.dropDownValue2 = permissionLabel;
+    _model.dropDownValueController2 =
+        FormFieldController<String>(permissionLabel);
+    _hasInitializedLocalizedValues = true;
+  }
 
-    super.dispose();
+  @override
+  void didUpdateWidget(AccountManageRowWidget oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (!_model.isEditing) {
+      _model.nameTextController?.text = widget.post.name ?? '';
+      _model.phoneTextController?.text = widget.post.phone ?? '';
+      final userTypeLabel = _userTypeLabel(widget.post.userType);
+      _model.dropDownValue1 = userTypeLabel;
+      _model.dropDownValueController1?.value = userTypeLabel;
+      final permissionLabel =
+          _permissionLabelFromLevel(widget.post.permissionLevel ?? 1);
+      _model.dropDownValue2 = permissionLabel;
+      _model.dropDownValueController2?.value = permissionLabel;
+      _hasInitializedLocalizedValues = true;
+    }
+  }
+
+  String _permissionLabelFromLevel(int level) {
+    return level >= 2
+        ? FFLocalizations.of(context).getText('cvxeomw7' /* 마스터 */)
+        : FFLocalizations.of(context).getText('1pk19gyt' /* 멤버 */);
+  }
+
+  String _userTypeLabel(int? userType) {
+    switch (userType) {
+      case 0:
+        return '마스터';
+      case 1:
+        return '전임';
+      case 2:
+        return '겸임';
+      case 4:
+        return '조교';
+      case 3:
+      default:
+        return '일반';
+    }
+  }
+
+  int _userTypeValueFromLabel(String? label) {
+    switch (label) {
+      case '마스터':
+        return 0;
+      case '전임':
+        return 1;
+      case '겸임':
+        return 2;
+      case '조교':
+        return 4;
+      case '일반':
+      default:
+        return 3;
+    }
+  }
+
+  int _permissionLevelFromLabel(String label) {
+    final masterLabel = FFLocalizations.of(context).getText('cvxeomw7');
+    return label == masterLabel ? 2 : 1;
+  }
+
+  void _enterEditMode() {
+    _model.isEditing = true;
+    _model.nameTextController?.text = widget.post.name ?? '';
+    _model.phoneTextController?.text = widget.post.phone ?? '';
+    final userTypeLabel = _userTypeLabel(widget.post.userType);
+    _model.dropDownValue1 = userTypeLabel;
+    _model.dropDownValueController1?.value = userTypeLabel;
+    final permissionLabel =
+        _permissionLabelFromLevel(widget.post.permissionLevel ?? 1);
+    _model.dropDownValue2 = permissionLabel;
+    _model.dropDownValueController2?.value = permissionLabel;
+    safeSetState(() {});
+  }
+
+  Future<void> _saveChanges() async {
+    final updatedData = <String, dynamic>{};
+    final newName = _model.nameTextController?.text.trim() ?? '';
+    final newPhone = _model.phoneTextController?.text.trim() ?? '';
+    final newUserTypeLabel =
+        _model.dropDownValue1 ?? _userTypeLabel(widget.post.userType);
+    final newPermissionLabel = _model.dropDownValue2 ??
+        FFLocalizations.of(context).getText('1pk19gyt');
+    final newPermission = _permissionLevelFromLabel(newPermissionLabel);
+
+    if (newName.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('이름을 입력해주세요.')),
+      );
+      return;
+    }
+
+    if (newName != (widget.post.name ?? '')) {
+      updatedData['name'] = newName;
+    }
+    final newUserType = _userTypeValueFromLabel(newUserTypeLabel);
+    if (widget.post.userType == null || widget.post.userType != newUserType) {
+      updatedData['user_type'] = newUserType;
+    }
+    if (newUserTypeLabel != (widget.post.position ?? '')) {
+      updatedData['position'] = newUserTypeLabel;
+    }
+    if (newPhone != (widget.post.phone ?? '')) {
+      updatedData['phone'] = newPhone;
+    }
+    if (newPermission != (widget.post.permissionLevel ?? 1)) {
+      updatedData['permission_level'] = newPermission;
+    }
+
+    if (updatedData.isEmpty) {
+      _model.isEditing = false;
+      safeSetState(() {});
+      return;
+    }
+
+    try {
+      _model.isSaving = true;
+      safeSetState(() {});
+      await PostsTable().update(
+        data: updatedData,
+        matchingRows: (rows) => rows.eq('id', widget.post.id),
+      );
+      _model.editedData = updatedData;
+      await widget.confirmEdit?.call(true, updatedData);
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('정보가 저장되었습니다.')),
+      );
+    } catch (e) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('저장에 실패했습니다: $e')),
+      );
+    } finally {
+      _model.isSaving = false;
+      _model.isEditing = false;
+      safeSetState(() {});
+    }
+  }
+
+  Future<void> _handleButtonPressed() async {
+    if (_model.isSaving) {
+      return;
+    }
+    if (!_model.isEditing) {
+      _enterEditMode();
+      return;
+    }
+    await _saveChanges();
   }
 
   @override
   Widget build(BuildContext context) {
-    return ListView(
-      padding: EdgeInsets.zero,
-      shrinkWrap: true,
-      scrollDirection: Axis.vertical,
-      children: [
-        Padding(
-          padding: EdgeInsetsDirectional.fromSTEB(20.0, 0.0, 20.0, 0.0),
-          child: Row(
-            mainAxisSize: MainAxisSize.max,
-            mainAxisAlignment: MainAxisAlignment.spaceAround,
-            children: [
-              Expanded(
-                flex: 1,
-                child: Container(
-                  decoration: BoxDecoration(),
-                  alignment: AlignmentDirectional(0.0, 0.0),
-                  child: Text(
-                    widget.professorName,
-                    style: FlutterFlowTheme.of(context).bodyMedium.override(
-                          font: GoogleFonts.inter(
-                            fontWeight: FontWeight.w500,
-                            fontStyle: FlutterFlowTheme.of(context)
-                                .bodyMedium
-                                .fontStyle,
-                          ),
-                          color: Color(0xFF4E4E4E),
-                          fontSize: 20.0,
-                          letterSpacing: 0.0,
-                          fontWeight: FontWeight.w500,
-                          fontStyle:
-                              FlutterFlowTheme.of(context).bodyMedium.fontStyle,
+    final positionOptions = [
+      _userTypeLabel(0),
+      _userTypeLabel(1),
+      _userTypeLabel(2),
+      _userTypeLabel(3),
+      _userTypeLabel(4),
+    ];
+    final permissionOptions = [
+      FFLocalizations.of(context).getText('1pk19gyt' /* 멤버 */),
+      FFLocalizations.of(context).getText('cvxeomw7' /* 마스터 */),
+    ];
+
+    final nameStyle = FlutterFlowTheme.of(context).bodyMedium.override(
+          font: GoogleFonts.inter(
+            fontWeight: FontWeight.w500,
+            fontStyle: FlutterFlowTheme.of(context).bodyMedium.fontStyle,
+          ),
+          color: const Color(0xFF4E4E4E),
+          fontSize: 20.0,
+          letterSpacing: 0.0,
+          fontWeight: FontWeight.w500,
+          fontStyle: FlutterFlowTheme.of(context).bodyMedium.fontStyle,
+        );
+
+    return InkWell(
+      onTap: _model.isEditing ? null : widget.onSelected,
+      child: Container(
+        padding: const EdgeInsets.symmetric(vertical: 10.0, horizontal: 20.0),
+        child: Row(
+          mainAxisSize: MainAxisSize.max,
+          mainAxisAlignment: MainAxisAlignment.start,
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            Expanded(
+              flex: 1,
+              child: Padding(
+                padding: const EdgeInsetsDirectional.fromSTEB(
+                    8.0, 0.0, 8.0, 0.0),
+                child: Align(
+                  alignment: Alignment.center,
+                  child: _model.isEditing
+                    ? TextFormField(
+                        controller: _model.nameTextController,
+                        focusNode: _model.nameFocusNode,
+                        autofocus: true,
+                        decoration: const InputDecoration(
+                          isDense: true,
+                          border: UnderlineInputBorder(),
                         ),
-                  ),
-                ),
-              ),
-              Expanded(
-                flex: 1,
-                child: Container(
-                  decoration: BoxDecoration(),
-                  alignment: AlignmentDirectional(0.0, 0.0),
-                  child: FlutterFlowDropDown<String>(
-                    controller: _model.dropDownValueController1 ??=
-                        FormFieldController<String>(null),
-                    options: [
-                      FFLocalizations.of(context).getText(
-                        'knb7lib7' /* PD교수 */,
-                      ),
-                      FFLocalizations.of(context).getText(
-                        'w82m8xf4' /* 정교수 */,
-                      ),
-                      FFLocalizations.of(context).getText(
-                        'l14d8d4d' /* 부교수 */,
-                      ),
-                      FFLocalizations.of(context).getText(
-                        'bdppbwit' /* 겸임교수 */,
-                      ),
-                      FFLocalizations.of(context).getText(
-                        'fpcbi6f2' /* 인증조교 */,
+                        style: nameStyle,
                       )
-                    ],
-                    onChanged: (val) =>
-                        safeSetState(() => _model.dropDownValue1 = val),
-                    width: 200.0,
-                    height: 40.0,
-                    textStyle: FlutterFlowTheme.of(context).bodyMedium.override(
-                          font: GoogleFonts.openSans(
-                            fontWeight: FlutterFlowTheme.of(context)
-                                .bodyMedium
-                                .fontWeight,
-                            fontStyle: FlutterFlowTheme.of(context)
-                                .bodyMedium
-                                .fontStyle,
-                          ),
-                          letterSpacing: 0.0,
-                          fontWeight: FlutterFlowTheme.of(context)
-                              .bodyMedium
-                              .fontWeight,
-                          fontStyle:
-                              FlutterFlowTheme.of(context).bodyMedium.fontStyle,
-                        ),
-                    hintText: FFLocalizations.of(context).getText(
-                      'yt5tcduf' /* 직급 선택 */,
-                    ),
-                    icon: Icon(
-                      Icons.keyboard_arrow_down_rounded,
-                      color: FlutterFlowTheme.of(context).secondaryText,
-                      size: 20.0,
-                    ),
-                    fillColor: FlutterFlowTheme.of(context).secondaryBackground,
-                    elevation: 2.0,
-                    borderColor: Colors.transparent,
-                    borderWidth: 0.0,
-                    borderRadius: 8.0,
-                    margin:
-                        EdgeInsetsDirectional.fromSTEB(12.0, 0.0, 12.0, 0.0),
-                    hidesUnderline: true,
-                    isOverButton: false,
-                    isSearchable: false,
-                    isMultiSelect: false,
-                  ),
-                ),
-              ),
-              Expanded(
-                flex: 3,
-                child: Container(
-                  decoration: BoxDecoration(),
-                  alignment: AlignmentDirectional(0.0, 0.0),
-                  child: Text(
-                    widget.professorEmail,
-                    style: FlutterFlowTheme.of(context).bodyMedium.override(
-                          font: GoogleFonts.inter(
-                            fontWeight: FontWeight.w500,
-                            fontStyle: FlutterFlowTheme.of(context)
-                                .bodyMedium
-                                .fontStyle,
-                          ),
-                          color: Color(0xFF4E4E4E),
-                          fontSize: 20.0,
-                          letterSpacing: 0.0,
-                          fontWeight: FontWeight.w500,
-                          fontStyle:
-                              FlutterFlowTheme.of(context).bodyMedium.fontStyle,
-                        ),
-                  ),
-                ),
-              ),
-              Expanded(
-                flex: 2,
-                child: Container(
-                  decoration: BoxDecoration(),
-                  alignment: AlignmentDirectional(0.0, 0.0),
-                  child: Text(
-                    widget.professorContact,
-                    style: FlutterFlowTheme.of(context).bodyMedium.override(
-                          font: GoogleFonts.inter(
-                            fontWeight: FontWeight.w500,
-                            fontStyle: FlutterFlowTheme.of(context)
-                                .bodyMedium
-                                .fontStyle,
-                          ),
-                          color: Color(0xFF4E4E4E),
-                          fontSize: 20.0,
-                          letterSpacing: 0.0,
-                          fontWeight: FontWeight.w500,
-                          fontStyle:
-                              FlutterFlowTheme.of(context).bodyMedium.fontStyle,
-                        ),
-                  ),
-                ),
-              ),
-              Expanded(
-                flex: 1,
-                child: Container(
-                  decoration: BoxDecoration(),
-                  alignment: AlignmentDirectional(0.0, 0.0),
-                  child: FlutterFlowDropDown<String>(
-                    controller: _model.dropDownValueController2 ??=
-                        FormFieldController<String>(null),
-                    options: [
-                      FFLocalizations.of(context).getText(
-                        '1pk19gyt' /* 멤버 */,
+                    : Text(
+                        widget.post.name ?? '-',
+                        style: nameStyle,
                       ),
-                      FFLocalizations.of(context).getText(
-                        'cvxeomw7' /* 마스터 */,
-                      )
-                    ],
-                    onChanged: (val) =>
-                        safeSetState(() => _model.dropDownValue2 = val),
-                    width: 200.0,
-                    height: 40.0,
-                    textStyle: FlutterFlowTheme.of(context).bodyMedium.override(
-                          font: GoogleFonts.openSans(
-                            fontWeight: FlutterFlowTheme.of(context)
-                                .bodyMedium
-                                .fontWeight,
-                            fontStyle: FlutterFlowTheme.of(context)
-                                .bodyMedium
-                                .fontStyle,
-                          ),
-                          letterSpacing: 0.0,
-                          fontWeight: FlutterFlowTheme.of(context)
-                              .bodyMedium
-                              .fontWeight,
-                          fontStyle:
-                              FlutterFlowTheme.of(context).bodyMedium.fontStyle,
+                ),
+              ),
+            ),
+            Expanded(
+              flex: 1,
+              child: Padding(
+                padding: const EdgeInsetsDirectional.fromSTEB(
+                    8.0, 0.0, 8.0, 0.0),
+                child: Align(
+                  alignment: Alignment.center,
+                  child: _model.isEditing
+                    ? FlutterFlowDropDown<String>(
+                        controller: _model.dropDownValueController1 ??=
+                            FormFieldController<String>(
+                          _model.dropDownValue1 ??
+                              _userTypeLabel(widget.post.userType),
                         ),
-                    hintText: FFLocalizations.of(context).getText(
-                      'res31ula' /* 권한선택 */,
-                    ),
-                    icon: Icon(
-                      Icons.keyboard_arrow_down_rounded,
-                      color: FlutterFlowTheme.of(context).secondaryText,
-                      size: 20.0,
-                    ),
-                    fillColor: FlutterFlowTheme.of(context).secondaryBackground,
-                    elevation: 2.0,
-                    borderColor: Colors.transparent,
-                    borderWidth: 0.0,
-                    borderRadius: 8.0,
-                    margin:
-                        EdgeInsetsDirectional.fromSTEB(12.0, 0.0, 12.0, 0.0),
-                    hidesUnderline: true,
-                    isOverButton: false,
-                    isSearchable: false,
-                    isMultiSelect: false,
+                        options: positionOptions,
+                        onChanged: (val) =>
+                            safeSetState(() => _model.dropDownValue1 = val),
+                        width: double.infinity,
+                        height: 40.0,
+                        textStyle: FlutterFlowTheme.of(context)
+                            .bodyMedium
+                            .override(
+                              font: GoogleFonts.openSans(
+                                fontWeight: FlutterFlowTheme.of(context)
+                                    .bodyMedium
+                                    .fontWeight,
+                                fontStyle: FlutterFlowTheme.of(context)
+                                    .bodyMedium
+                                    .fontStyle,
+                              ),
+                              letterSpacing: 0.0,
+                              fontWeight: FlutterFlowTheme.of(context)
+                                  .bodyMedium
+                                  .fontWeight,
+                              fontStyle: FlutterFlowTheme.of(context)
+                                  .bodyMedium
+                                  .fontStyle,
+                            ),
+                        hintText: FFLocalizations.of(context)
+                            .getText('yt5tcduf' /* 직급 선택 */),
+                        icon: Icon(
+                          Icons.keyboard_arrow_down_rounded,
+                          color: FlutterFlowTheme.of(context).secondaryText,
+                          size: 20.0,
+                        ),
+                        fillColor:
+                            FlutterFlowTheme.of(context).secondaryBackground,
+                        elevation: 2.0,
+                        borderColor: Colors.transparent,
+                        borderWidth: 0.0,
+                        borderRadius: 8.0,
+                        margin: const EdgeInsetsDirectional.fromSTEB(
+                            8.0, 0.0, 8.0, 0.0),
+                        hidesUnderline: true,
+                        isOverButton: false,
+                        isSearchable: false,
+                        isMultiSelect: false,
+                      )
+                    : Text(
+                        _userTypeLabel(widget.post.userType),
+                        style: nameStyle,
+                      ),
+                ),
+              ),
+            ),
+            Expanded(
+              flex: 3,
+              child: Padding(
+                padding: const EdgeInsetsDirectional.fromSTEB(
+                    8.0, 0.0, 8.0, 0.0),
+                child: Align(
+                  alignment: Alignment.centerLeft,
+                  child: Text(
+                    widget.post.email ?? '-',
+                    style: nameStyle,
                   ),
                 ),
               ),
-              Expanded(
-                flex: 1,
-                child: Container(
-                  decoration: BoxDecoration(),
-                  alignment: AlignmentDirectional(0.0, 0.0),
+            ),
+            Expanded(
+              flex: 2,
+              child: Padding(
+                padding: const EdgeInsetsDirectional.fromSTEB(
+                    8.0, 0.0, 8.0, 0.0),
+                child: Align(
+                  alignment: Alignment.center,
+                  child: _model.isEditing
+                      ? TextFormField(
+                          controller: _model.phoneTextController,
+                          focusNode: _model.phoneFocusNode,
+                          decoration: const InputDecoration(
+                            isDense: true,
+                            border: UnderlineInputBorder(),
+                          ),
+                          style: nameStyle,
+                        )
+                      : Text(
+                          widget.post.phone ?? '-',
+                          style: nameStyle,
+                        ),
+                ),
+              ),
+            ),
+            Expanded(
+              flex: 1,
+              child: Padding(
+                padding: const EdgeInsetsDirectional.fromSTEB(
+                    8.0, 0.0, 8.0, 0.0),
+                child: Align(
+                  alignment: Alignment.center,
+                  child: _model.isEditing
+                    ? FlutterFlowDropDown<String>(
+                        controller: _model.dropDownValueController2 ??=
+                            FormFieldController<String>(
+                          _model.dropDownValue2 ??
+                              _permissionLabelFromLevel(
+                                  widget.post.permissionLevel ?? 1),
+                        ),
+                        options: permissionOptions,
+                        onChanged: (val) =>
+                            safeSetState(() => _model.dropDownValue2 = val),
+                        width: double.infinity,
+                        height: 40.0,
+                        textStyle: FlutterFlowTheme.of(context)
+                            .bodyMedium
+                            .override(
+                              font: GoogleFonts.openSans(
+                                fontWeight: FlutterFlowTheme.of(context)
+                                    .bodyMedium
+                                    .fontWeight,
+                                fontStyle: FlutterFlowTheme.of(context)
+                                    .bodyMedium
+                                    .fontStyle,
+                              ),
+                              letterSpacing: 0.0,
+                              fontWeight: FlutterFlowTheme.of(context)
+                                  .bodyMedium
+                                  .fontWeight,
+                              fontStyle: FlutterFlowTheme.of(context)
+                                  .bodyMedium
+                                  .fontStyle,
+                            ),
+                        hintText: FFLocalizations.of(context)
+                            .getText('res31ula' /* 권한선택 */),
+                        icon: Icon(
+                          Icons.keyboard_arrow_down_rounded,
+                          color: FlutterFlowTheme.of(context).secondaryText,
+                          size: 20.0,
+                        ),
+                        fillColor:
+                            FlutterFlowTheme.of(context).secondaryBackground,
+                        elevation: 2.0,
+                        borderColor: Colors.transparent,
+                        borderWidth: 0.0,
+                        borderRadius: 8.0,
+                        margin: const EdgeInsetsDirectional.fromSTEB(
+                            8.0, 0.0, 8.0, 0.0),
+                        hidesUnderline: true,
+                        isOverButton: false,
+                        isSearchable: false,
+                        isMultiSelect: false,
+                      )
+                    : Text(
+                        _permissionLabelFromLevel(
+                            widget.post.permissionLevel ?? 1),
+                        style: nameStyle,
+                      ),
+                ),
+              ),
+            ),
+            Expanded(
+              flex: 1,
+              child: Padding(
+                padding: const EdgeInsetsDirectional.fromSTEB(
+                    8.0, 0.0, 8.0, 0.0),
+                child: SizedBox(
+                  height: 36.0,
                   child: FFButtonWidget(
-                    onPressed: () {
-                      print('Button pressed ...');
-                    },
-                    text: widget.isEditing ? '완료' : '수정',
+                    onPressed: _handleButtonPressed,
+                    text: _model.isSaving
+                        ? '저장중'
+                        : (_model.isEditing
+                            ? '완료'
+                            : FFLocalizations.of(context)
+                                .getText('ndcle0l5' /* 수정 */)),
                     options: FFButtonOptions(
-                      width: 100.0,
-                      height: 30.0,
-                      padding:
-                          EdgeInsetsDirectional.fromSTEB(16.0, 0.0, 16.0, 0.0),
-                      iconPadding:
-                          EdgeInsetsDirectional.fromSTEB(0.0, 0.0, 0.0, 0.0),
-                      color: widget.isEditing
+                      width: double.infinity,
+                      height: 36.0,
+                      padding: const EdgeInsetsDirectional.fromSTEB(
+                          16.0, 0.0, 16.0, 0.0),
+                      iconPadding: const EdgeInsetsDirectional.fromSTEB(
+                          0.0, 0.0, 0.0, 0.0),
+                      color: _model.isEditing
                           ? FlutterFlowTheme.of(context).mainColor1
                           : Colors.white,
                       textStyle:
@@ -301,9 +479,9 @@ class _AccountManageRowWidgetState extends State<AccountManageRowWidget> {
                                       .titleSmall
                                       .fontStyle,
                                 ),
-                                color: widget.isEditing
+                                color: _model.isEditing
                                     ? Colors.white
-                                    : Color(0xFF666666),
+                                    : const Color(0xFF666666),
                                 letterSpacing: 0.0,
                                 fontWeight: FlutterFlowTheme.of(context)
                                     .titleSmall
@@ -313,7 +491,7 @@ class _AccountManageRowWidgetState extends State<AccountManageRowWidget> {
                                     .fontStyle,
                               ),
                       elevation: 0.0,
-                      borderSide: BorderSide(
+                      borderSide: const BorderSide(
                         color: Color(0xFF666666),
                         width: 0.5,
                       ),
@@ -322,10 +500,10 @@ class _AccountManageRowWidgetState extends State<AccountManageRowWidget> {
                   ),
                 ),
               ),
-            ],
-          ),
+            ),
+          ],
         ),
-      ].divide(SizedBox(height: 10.0)),
+      ),
     );
   }
 }

--- a/lib/components/account_manage/account_manage_row_mobile/account_manage_row_mobile_model.dart
+++ b/lib/components/account_manage/account_manage_row_mobile/account_manage_row_mobile_model.dart
@@ -15,9 +15,31 @@ class AccountManageRowMobileModel
   String? dropDownValue2;
   FormFieldController<String>? dropDownValueController2;
 
-  @override
-  void initState(BuildContext context) {}
+  bool isEditing = false;
+
+  Map<String, dynamic> editedData = {};
+
+  FocusNode? nameFocusNode;
+
+  TextEditingController? nameTextController;
+
+  FocusNode? phoneFocusNode;
+
+  TextEditingController? phoneTextController;
+
+  bool isSaving = false;
 
   @override
-  void dispose() {}
+  void initState(BuildContext context) {
+    nameFocusNode = FocusNode();
+    phoneFocusNode = FocusNode();
+  }
+
+  @override
+  void dispose() {
+    nameFocusNode?.dispose();
+    nameTextController?.dispose();
+    phoneFocusNode?.dispose();
+    phoneTextController?.dispose();
+  }
 }

--- a/lib/components/account_manage/account_manage_row_mobile/account_manage_row_mobile_widget.dart
+++ b/lib/components/account_manage/account_manage_row_mobile/account_manage_row_mobile_widget.dart
@@ -1,3 +1,4 @@
+import '/backend/supabase/supabase.dart';
 import '/flutter_flow/flutter_flow_drop_down.dart';
 import '/flutter_flow/flutter_flow_theme.dart';
 import '/flutter_flow/flutter_flow_util.dart';
@@ -11,27 +12,15 @@ export 'account_manage_row_mobile_model.dart';
 class AccountManageRowMobileWidget extends StatefulWidget {
   const AccountManageRowMobileWidget({
     super.key,
-    String? professorName,
-    String? professorRole,
-    String? professorEmail,
-    String? professorContact,
-    String? professorAuthority,
+    required this.post,
     this.confirmEdit,
-    bool? isEditing,
-  })  : this.professorName = professorName ?? '홍길동',
-        this.professorRole = professorRole ?? 'PD교수',
-        this.professorEmail = professorEmail ?? 'professor@schd.co.kr',
-        this.professorContact = professorContact ?? '010-1234-5678',
-        this.professorAuthority = professorAuthority ?? '마스터',
-        this.isEditing = isEditing ?? false;
+    this.onSelected,
+  });
 
-  final String professorName;
-  final String professorRole;
-  final String professorEmail;
-  final String professorContact;
-  final String professorAuthority;
-  final Future Function(bool confirm)? confirmEdit;
-  final bool isEditing;
+  final PostsRow post;
+  final Future<void> Function(bool confirm, Map<String, dynamic> updatedData)?
+      confirmEdit;
+  final VoidCallback? onSelected;
 
   @override
   State<AccountManageRowMobileWidget> createState() =>
@@ -41,6 +30,7 @@ class AccountManageRowMobileWidget extends StatefulWidget {
 class _AccountManageRowMobileWidgetState
     extends State<AccountManageRowMobileWidget> {
   late AccountManageRowMobileModel _model;
+  bool _hasInitializedLocalizedValues = false;
 
   @override
   void setState(VoidCallback callback) {
@@ -52,234 +42,438 @@ class _AccountManageRowMobileWidgetState
   void initState() {
     super.initState();
     _model = createModel(context, () => AccountManageRowMobileModel());
+    _model.nameTextController ??=
+        TextEditingController(text: widget.post.name ?? '');
+    _model.phoneTextController ??=
+        TextEditingController(text: widget.post.phone ?? '');
+    final initialUserTypeLabel = _userTypeLabel(widget.post.userType);
+    _model.dropDownValue1 = initialUserTypeLabel;
+    _model.dropDownValueController1 =
+        FormFieldController<String>(initialUserTypeLabel);
 
     WidgetsBinding.instance.addPostFrameCallback((_) => safeSetState(() {}));
   }
 
   @override
-  void dispose() {
-    _model.maybeDispose();
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    if (_hasInitializedLocalizedValues) {
+      return;
+    }
+    final permissionLabel =
+        _permissionLabelFromLevel(widget.post.permissionLevel ?? 1);
+    _model.dropDownValue2 = permissionLabel;
+    _model.dropDownValueController2 =
+        FormFieldController<String>(permissionLabel);
+    _hasInitializedLocalizedValues = true;
+  }
 
-    super.dispose();
+  @override
+  void didUpdateWidget(AccountManageRowMobileWidget oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (!_model.isEditing) {
+      _model.nameTextController?.text = widget.post.name ?? '';
+      _model.phoneTextController?.text = widget.post.phone ?? '';
+      final userTypeLabel = _userTypeLabel(widget.post.userType);
+      _model.dropDownValue1 = userTypeLabel;
+      _model.dropDownValueController1?.value = userTypeLabel;
+      final permissionLabel =
+          _permissionLabelFromLevel(widget.post.permissionLevel ?? 1);
+      _model.dropDownValue2 = permissionLabel;
+      _model.dropDownValueController2?.value = permissionLabel;
+      _hasInitializedLocalizedValues = true;
+    }
+  }
+
+  String _permissionLabelFromLevel(int level) {
+    return level >= 2
+        ? FFLocalizations.of(context).getText('alvyj0rj' /* 마스터 */)
+        : FFLocalizations.of(context).getText('qndnhdqy' /* 멤버 */);
+  }
+
+  String _userTypeLabel(int? userType) {
+    switch (userType) {
+      case 0:
+        return '마스터';
+      case 1:
+        return '전임';
+      case 2:
+        return '겸임';
+      case 4:
+        return '조교';
+      case 3:
+      default:
+        return '일반';
+    }
+  }
+
+  int _userTypeValueFromLabel(String? label) {
+    switch (label) {
+      case '마스터':
+        return 0;
+      case '전임':
+        return 1;
+      case '겸임':
+        return 2;
+      case '조교':
+        return 4;
+      case '일반':
+      default:
+        return 3;
+    }
+  }
+
+  int _permissionLevelFromLabel(String label) {
+    final masterLabel = FFLocalizations.of(context).getText('alvyj0rj');
+    return label == masterLabel ? 2 : 1;
+  }
+
+  void _enterEditMode() {
+    _model.isEditing = true;
+    _model.nameTextController?.text = widget.post.name ?? '';
+    _model.phoneTextController?.text = widget.post.phone ?? '';
+    final userTypeLabel = _userTypeLabel(widget.post.userType);
+    _model.dropDownValue1 = userTypeLabel;
+    _model.dropDownValueController1?.value = userTypeLabel;
+    final permissionLabel =
+        _permissionLabelFromLevel(widget.post.permissionLevel ?? 1);
+    _model.dropDownValue2 = permissionLabel;
+    _model.dropDownValueController2?.value = permissionLabel;
+    safeSetState(() {});
+  }
+
+  Future<void> _saveChanges() async {
+    final updatedData = <String, dynamic>{};
+    final newName = _model.nameTextController?.text.trim() ?? '';
+    final newPhone = _model.phoneTextController?.text.trim() ?? '';
+    final newUserTypeLabel =
+        _model.dropDownValue1 ?? _userTypeLabel(widget.post.userType);
+    final newPermissionLabel =
+        _model.dropDownValue2 ?? FFLocalizations.of(context).getText('qndnhdqy');
+    final newPermission = _permissionLevelFromLabel(newPermissionLabel);
+
+    if (newName.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('이름을 입력해주세요.')),
+      );
+      return;
+    }
+
+    if (newName != (widget.post.name ?? '')) {
+      updatedData['name'] = newName;
+    }
+    final newUserType = _userTypeValueFromLabel(newUserTypeLabel);
+    if (widget.post.userType == null || widget.post.userType != newUserType) {
+      updatedData['user_type'] = newUserType;
+    }
+    if (newUserTypeLabel != (widget.post.position ?? '')) {
+      updatedData['position'] = newUserTypeLabel;
+    }
+    if (newPhone != (widget.post.phone ?? '')) {
+      updatedData['phone'] = newPhone;
+    }
+    if (newPermission != (widget.post.permissionLevel ?? 1)) {
+      updatedData['permission_level'] = newPermission;
+    }
+
+    if (updatedData.isEmpty) {
+      _model.isEditing = false;
+      safeSetState(() {});
+      return;
+    }
+
+    try {
+      _model.isSaving = true;
+      safeSetState(() {});
+      await PostsTable().update(
+        data: updatedData,
+        matchingRows: (rows) => rows.eq('id', widget.post.id),
+      );
+      _model.editedData = updatedData;
+      await widget.confirmEdit?.call(true, updatedData);
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('정보가 저장되었습니다.')),
+      );
+    } catch (e) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('저장에 실패했습니다: $e')),
+      );
+    } finally {
+      _model.isSaving = false;
+      _model.isEditing = false;
+      safeSetState(() {});
+    }
+  }
+
+  Future<void> _handleButtonPressed() async {
+    if (_model.isSaving) {
+      return;
+    }
+    if (!_model.isEditing) {
+      _enterEditMode();
+      return;
+    }
+    await _saveChanges();
   }
 
   @override
   Widget build(BuildContext context) {
-    return ListView(
-      padding: EdgeInsets.zero,
-      shrinkWrap: true,
-      scrollDirection: Axis.vertical,
-      children: [
-        Padding(
-          padding: EdgeInsetsDirectional.fromSTEB(10.0, 0.0, 10.0, 0.0),
-          child: Row(
-            mainAxisSize: MainAxisSize.max,
-            mainAxisAlignment: MainAxisAlignment.spaceAround,
-            children: [
-              Expanded(
-                flex: 1,
-                child: Container(
-                  decoration: BoxDecoration(),
-                  alignment: AlignmentDirectional(0.0, 0.0),
-                  child: Text(
-                    widget.professorName,
-                    style: FlutterFlowTheme.of(context).bodyMedium.override(
-                          font: GoogleFonts.inter(
-                            fontWeight: FontWeight.w500,
-                            fontStyle: FlutterFlowTheme.of(context)
-                                .bodyMedium
-                                .fontStyle,
+    final positionOptions = [
+      _userTypeLabel(0),
+      _userTypeLabel(1),
+      _userTypeLabel(2),
+      _userTypeLabel(3),
+      _userTypeLabel(4),
+    ];
+    final permissionOptions = [
+      FFLocalizations.of(context).getText('qndnhdqy' /* 멤버 */),
+      FFLocalizations.of(context).getText('alvyj0rj' /* 마스터 */),
+    ];
+
+    final textStyle = FlutterFlowTheme.of(context).bodyMedium.override(
+          font: GoogleFonts.inter(
+            fontWeight: FontWeight.w500,
+            fontStyle: FlutterFlowTheme.of(context).bodyMedium.fontStyle,
+          ),
+          color: const Color(0xFF4E4E4E),
+          fontSize: 13.0,
+          letterSpacing: 0.0,
+          fontWeight: FontWeight.w500,
+          fontStyle: FlutterFlowTheme.of(context).bodyMedium.fontStyle,
+        );
+
+    return InkWell(
+      onTap: _model.isEditing ? null : widget.onSelected,
+      child: Container(
+        padding: const EdgeInsets.symmetric(vertical: 10.0, horizontal: 20.0),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Row(
+              mainAxisSize: MainAxisSize.max,
+              mainAxisAlignment: MainAxisAlignment.start,
+              crossAxisAlignment: CrossAxisAlignment.center,
+              children: [
+                Expanded(
+                  flex: 1,
+                  child: Padding(
+                    padding: const EdgeInsetsDirectional.fromSTEB(
+                        6.0, 0.0, 6.0, 0.0),
+                    child: Align(
+                      alignment: Alignment.centerLeft,
+                      child: _model.isEditing
+                        ? TextFormField(
+                            controller: _model.nameTextController,
+                            focusNode: _model.nameFocusNode,
+                            decoration: const InputDecoration(
+                              isDense: true,
+                              border: UnderlineInputBorder(),
+                            ),
+                            style: textStyle,
+                          )
+                        : Text(
+                            widget.post.name ?? '-',
+                            style: textStyle,
                           ),
-                          color: Color(0xFF4E4E4E),
-                          fontSize: 13.0,
-                          letterSpacing: 0.0,
-                          fontWeight: FontWeight.w500,
-                          fontStyle:
-                              FlutterFlowTheme.of(context).bodyMedium.fontStyle,
-                        ),
+                    ),
                   ),
                 ),
-              ),
-              Expanded(
-                flex: 1,
-                child: Container(
-                  decoration: BoxDecoration(),
-                  alignment: AlignmentDirectional(0.0, 0.0),
-                  child: FlutterFlowDropDown<String>(
-                    controller: _model.dropDownValueController1 ??=
-                        FormFieldController<String>(null),
-                    options: [
-                      FFLocalizations.of(context).getText(
-                        'mb3npfo1' /* PD교수 */,
-                      ),
-                      FFLocalizations.of(context).getText(
-                        '0vhldvlp' /* 정교수 */,
-                      ),
-                      FFLocalizations.of(context).getText(
-                        '3e1pixer' /* 부교수 */,
-                      ),
-                      FFLocalizations.of(context).getText(
-                        'm0j5ogkh' /* 겸임교수 */,
-                      ),
-                      FFLocalizations.of(context).getText(
-                        'dh76ex0t' /* 인증조교 */,
-                      )
-                    ],
-                    onChanged: (val) =>
-                        safeSetState(() => _model.dropDownValue1 = val),
-                    height: 40.0,
-                    textStyle: FlutterFlowTheme.of(context).bodyMedium.override(
-                          font: GoogleFonts.openSans(
-                            fontWeight: FlutterFlowTheme.of(context)
+                Expanded(
+                  flex: 1,
+                  child: Padding(
+                    padding: const EdgeInsetsDirectional.fromSTEB(
+                        6.0, 0.0, 6.0, 0.0),
+                    child: Align(
+                      alignment: Alignment.center,
+                      child: _model.isEditing
+                        ? FlutterFlowDropDown<String>(
+                            controller: _model.dropDownValueController1 ??=
+                                FormFieldController<String>(
+                              _model.dropDownValue1 ??
+                                  _userTypeLabel(widget.post.userType),
+                            ),
+                            options: positionOptions,
+                            onChanged: (val) =>
+                                safeSetState(() => _model.dropDownValue1 = val),
+                            width: double.infinity,
+                            height: 40.0,
+                            textStyle: FlutterFlowTheme.of(context)
                                 .bodyMedium
-                                .fontWeight,
-                            fontStyle: FlutterFlowTheme.of(context)
-                                .bodyMedium
-                                .fontStyle,
-                          ),
-                          fontSize: 13.0,
-                          letterSpacing: 0.0,
-                          fontWeight: FlutterFlowTheme.of(context)
-                              .bodyMedium
-                              .fontWeight,
-                          fontStyle:
-                              FlutterFlowTheme.of(context).bodyMedium.fontStyle,
-                        ),
-                    hintText: FFLocalizations.of(context).getText(
-                      'z343ki7l' /* 직급 */,
-                    ),
-                    icon: Icon(
-                      Icons.keyboard_arrow_down_rounded,
-                      color: FlutterFlowTheme.of(context).secondaryText,
-                      size: 20.0,
-                    ),
-                    fillColor: FlutterFlowTheme.of(context).secondaryBackground,
-                    elevation: 2.0,
-                    borderColor: Colors.transparent,
-                    borderWidth: 0.0,
-                    borderRadius: 8.0,
-                    margin:
-                        EdgeInsetsDirectional.fromSTEB(12.0, 0.0, 12.0, 0.0),
-                    hidesUnderline: true,
-                    isOverButton: false,
-                    isSearchable: false,
-                    isMultiSelect: false,
-                  ),
-                ),
-              ),
-              Expanded(
-                flex: 1,
-                child: Container(
-                  decoration: BoxDecoration(),
-                  alignment: AlignmentDirectional(0.0, 0.0),
-                  child: FlutterFlowDropDown<String>(
-                    controller: _model.dropDownValueController2 ??=
-                        FormFieldController<String>(null),
-                    options: [
-                      FFLocalizations.of(context).getText(
-                        'qndnhdqy' /* 멤버 */,
-                      ),
-                      FFLocalizations.of(context).getText(
-                        'alvyj0rj' /* 마스터 */,
-                      )
-                    ],
-                    onChanged: (val) =>
-                        safeSetState(() => _model.dropDownValue2 = val),
-                    height: 40.0,
-                    textStyle: FlutterFlowTheme.of(context).bodyMedium.override(
-                          font: GoogleFonts.openSans(
-                            fontWeight: FlutterFlowTheme.of(context)
-                                .bodyMedium
-                                .fontWeight,
-                            fontStyle: FlutterFlowTheme.of(context)
-                                .bodyMedium
-                                .fontStyle,
-                          ),
-                          fontSize: 13.0,
-                          letterSpacing: 0.0,
-                          fontWeight: FlutterFlowTheme.of(context)
-                              .bodyMedium
-                              .fontWeight,
-                          fontStyle:
-                              FlutterFlowTheme.of(context).bodyMedium.fontStyle,
-                        ),
-                    hintText: FFLocalizations.of(context).getText(
-                      'b6a4fzbx' /* 권한 */,
-                    ),
-                    icon: Icon(
-                      Icons.keyboard_arrow_down_rounded,
-                      color: FlutterFlowTheme.of(context).secondaryText,
-                      size: 20.0,
-                    ),
-                    fillColor: FlutterFlowTheme.of(context).secondaryBackground,
-                    elevation: 2.0,
-                    borderColor: Colors.transparent,
-                    borderWidth: 0.0,
-                    borderRadius: 8.0,
-                    margin:
-                        EdgeInsetsDirectional.fromSTEB(12.0, 0.0, 12.0, 0.0),
-                    hidesUnderline: true,
-                    isOverButton: false,
-                    isSearchable: false,
-                    isMultiSelect: false,
-                  ),
-                ),
-              ),
-              Expanded(
-                flex: 1,
-                child: Container(
-                  decoration: BoxDecoration(),
-                  alignment: AlignmentDirectional(0.0, 0.0),
-                  child: FFButtonWidget(
-                    onPressed: () {
-                      print('Button pressed ...');
-                    },
-                    text: widget.isEditing ? '완료' : '수정',
-                    options: FFButtonOptions(
-                      width: 75.0,
-                      height: 30.0,
-                      padding:
-                          EdgeInsetsDirectional.fromSTEB(16.0, 0.0, 16.0, 0.0),
-                      iconPadding:
-                          EdgeInsetsDirectional.fromSTEB(0.0, 0.0, 0.0, 0.0),
-                      color: widget.isEditing
-                          ? FlutterFlowTheme.of(context).mainColor1
-                          : Colors.white,
-                      textStyle:
-                          FlutterFlowTheme.of(context).titleSmall.override(
-                                font: GoogleFonts.openSans(
+                                .override(
+                                  font: GoogleFonts.openSans(
+                                    fontWeight: FlutterFlowTheme.of(context)
+                                        .bodyMedium
+                                        .fontWeight,
+                                    fontStyle: FlutterFlowTheme.of(context)
+                                        .bodyMedium
+                                        .fontStyle,
+                                  ),
+                                  fontSize: 13.0,
+                                  letterSpacing: 0.0,
                                   fontWeight: FlutterFlowTheme.of(context)
-                                      .titleSmall
+                                      .bodyMedium
                                       .fontWeight,
                                   fontStyle: FlutterFlowTheme.of(context)
-                                      .titleSmall
+                                      .bodyMedium
                                       .fontStyle,
                                 ),
-                                color: widget.isEditing
-                                    ? Colors.white
-                                    : Color(0xFF666666),
-                                letterSpacing: 0.0,
-                                fontWeight: FlutterFlowTheme.of(context)
-                                    .titleSmall
-                                    .fontWeight,
-                                fontStyle: FlutterFlowTheme.of(context)
-                                    .titleSmall
-                                    .fontStyle,
-                              ),
-                      elevation: 0.0,
-                      borderSide: BorderSide(
-                        color: Color(0xFF666666),
-                        width: 0.5,
-                      ),
-                      borderRadius: BorderRadius.circular(5.0),
+                            hintText: FFLocalizations.of(context)
+                                .getText('z343ki7l' /* 직급 */),
+                            icon: Icon(
+                              Icons.keyboard_arrow_down_rounded,
+                              color: FlutterFlowTheme.of(context).secondaryText,
+                              size: 20.0,
+                            ),
+                            fillColor:
+                                FlutterFlowTheme.of(context).secondaryBackground,
+                            elevation: 2.0,
+                            borderColor: Colors.transparent,
+                            borderWidth: 0.0,
+                            borderRadius: 8.0,
+                            margin: const EdgeInsetsDirectional.fromSTEB(
+                                6.0, 0.0, 6.0, 0.0),
+                            hidesUnderline: true,
+                            isOverButton: false,
+                            isSearchable: false,
+                            isMultiSelect: false,
+                          )
+                        : Text(
+                            _userTypeLabel(widget.post.userType),
+                            style: textStyle,
+                          ),
                     ),
                   ),
                 ),
-              ),
-            ],
-          ),
+                Expanded(
+                  flex: 1,
+                  child: Padding(
+                    padding: const EdgeInsetsDirectional.fromSTEB(
+                        6.0, 0.0, 6.0, 0.0),
+                    child: Align(
+                      alignment: Alignment.center,
+                      child: _model.isEditing
+                        ? FlutterFlowDropDown<String>(
+                            controller: _model.dropDownValueController2 ??=
+                                FormFieldController<String>(
+                              _model.dropDownValue2 ??
+                                  _permissionLabelFromLevel(
+                                      widget.post.permissionLevel ?? 1),
+                            ),
+                            options: permissionOptions,
+                            onChanged: (val) =>
+                                safeSetState(() => _model.dropDownValue2 = val),
+                            width: double.infinity,
+                            height: 40.0,
+                            textStyle: FlutterFlowTheme.of(context)
+                                .bodyMedium
+                                .override(
+                                  font: GoogleFonts.openSans(
+                                    fontWeight: FlutterFlowTheme.of(context)
+                                        .bodyMedium
+                                        .fontWeight,
+                                    fontStyle: FlutterFlowTheme.of(context)
+                                        .bodyMedium
+                                        .fontStyle,
+                                  ),
+                                  fontSize: 13.0,
+                                  letterSpacing: 0.0,
+                                  fontWeight: FlutterFlowTheme.of(context)
+                                      .bodyMedium
+                                      .fontWeight,
+                                  fontStyle: FlutterFlowTheme.of(context)
+                                      .bodyMedium
+                                      .fontStyle,
+                                ),
+                            hintText: FFLocalizations.of(context)
+                                .getText('b6a4fzbx' /* 권한 */),
+                            icon: Icon(
+                              Icons.keyboard_arrow_down_rounded,
+                              color: FlutterFlowTheme.of(context).secondaryText,
+                              size: 20.0,
+                            ),
+                            fillColor:
+                                FlutterFlowTheme.of(context).secondaryBackground,
+                            elevation: 2.0,
+                            borderColor: Colors.transparent,
+                            borderWidth: 0.0,
+                            borderRadius: 8.0,
+                            margin: const EdgeInsetsDirectional.fromSTEB(
+                                6.0, 0.0, 6.0, 0.0),
+                            hidesUnderline: true,
+                            isOverButton: false,
+                            isSearchable: false,
+                            isMultiSelect: false,
+                          )
+                        : Text(
+                            _permissionLabelFromLevel(
+                                widget.post.permissionLevel ?? 1),
+                            style: textStyle,
+                          ),
+                    ),
+                  ),
+                ),
+                Expanded(
+                  flex: 1,
+                  child: Padding(
+                    padding: const EdgeInsetsDirectional.fromSTEB(
+                        6.0, 0.0, 6.0, 0.0),
+                    child: SizedBox(
+                      height: 34.0,
+                      child: FFButtonWidget(
+                        onPressed: _handleButtonPressed,
+                        text: _model.isSaving
+                            ? '저장중'
+                            : (_model.isEditing
+                                ? '완료'
+                                : FFLocalizations.of(context)
+                                    .getText('ndcle0l5' /* 수정 */)),
+                        options: FFButtonOptions(
+                          width: double.infinity,
+                          height: 34.0,
+                          padding: const EdgeInsetsDirectional.fromSTEB(
+                              12.0, 0.0, 12.0, 0.0),
+                          iconPadding: const EdgeInsetsDirectional.fromSTEB(
+                              0.0, 0.0, 0.0, 0.0),
+                          color: _model.isEditing
+                              ? FlutterFlowTheme.of(context).mainColor1
+                              : Colors.white,
+                          textStyle:
+                              FlutterFlowTheme.of(context).titleSmall.override(
+                                    font: GoogleFonts.openSans(
+                                      fontWeight: FlutterFlowTheme.of(context)
+                                          .titleSmall
+                                          .fontWeight,
+                                      fontStyle: FlutterFlowTheme.of(context)
+                                          .titleSmall
+                                          .fontStyle,
+                                    ),
+                                    color: _model.isEditing
+                                        ? Colors.white
+                                        : const Color(0xFF666666),
+                                    letterSpacing: 0.0,
+                                    fontWeight: FlutterFlowTheme.of(context)
+                                        .titleSmall
+                                        .fontWeight,
+                                    fontStyle: FlutterFlowTheme.of(context)
+                                        .titleSmall
+                                        .fontStyle,
+                                  ),
+                          elevation: 0.0,
+                          borderSide: const BorderSide(
+                            color: Color(0xFF666666),
+                            width: 0.5,
+                          ),
+                          borderRadius: BorderRadius.circular(5.0),
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ],
         ),
-      ].divide(SizedBox(height: 10.0)),
+      ),
     );
   }
 }

--- a/lib/components/default_layout/nav_bar/admin_navi_sidebar/admin_navi_sidebar_widget.dart
+++ b/lib/components/default_layout/nav_bar/admin_navi_sidebar/admin_navi_sidebar_widget.dart
@@ -606,8 +606,8 @@ class _AdminNaviSidebarWidgetState extends State<AdminNaviSidebarWidget> {
                                           FFIcons.kadminidicon,
                                           color: valueOrDefault<Color>(
                                             widget.activePageName ==
-                                                    'SubjectPortpolio'
-                                                ? Color(0xFF284E75)
+                                                    'AdminManager'
+                                                ? const Color(0xFF284E75)
                                                 : FlutterFlowTheme.of(context)
                                                     .primaryBackground,
                                             FlutterFlowTheme.of(context)

--- a/lib/custom_code/actions/index.dart
+++ b/lib/custom_code/actions/index.dart
@@ -4,3 +4,4 @@ export 'start_download_action.dart' show startDownloadAction;
 export 'debug_printing.dart' show debugPrinting;
 export 'fail_debug.dart' show failDebug;
 export 'get_class_documents.dart' show getClassDocuments;
+export 'search_posts.dart' show searchPosts;

--- a/lib/custom_code/actions/search_posts.dart
+++ b/lib/custom_code/actions/search_posts.dart
@@ -1,0 +1,49 @@
+// Automatic FlutterFlow imports
+import '/backend/schema/structs/index.dart';
+import '/backend/schema/enums/enums.dart';
+import '/backend/supabase/supabase.dart';
+import '/flutter_flow/flutter_flow_theme.dart';
+import '/flutter_flow/flutter_flow_util.dart';
+import 'index.dart'; // Imports other custom actions
+import 'package:flutter/material.dart';
+// Begin custom action code
+// DO NOT REMOVE OR MODIFY THE CODE ABOVE!
+
+Future<List<PostsRow>> searchPosts(String? searchType, String? searchText) async {
+  if (searchText == null || searchText.isEmpty) {
+    return await PostsTable().queryRows(
+      queryFn: (q) => q.order('name', ascending: true),
+    );
+  }
+
+  List<PostsRow> allRows;
+  try {
+    allRows = await PostsTable().queryRows(
+      queryFn: (q) => q.order('name', ascending: true),
+    );
+  } catch (e) {
+    debugPrint('데이터 로드 실패: $e');
+    return [];
+  }
+
+  final normalizedSearch = searchText.trim().toLowerCase();
+
+  if (searchType == '이 름') {
+    return allRows.where((row) {
+      final name = row.name?.toLowerCase() ?? '';
+      return name.contains(normalizedSearch);
+    }).toList();
+  }
+
+  if (searchType == '학 번' || searchType == '연락처') {
+    return allRows.where((row) {
+      final phone = row.phone ?? '';
+      return phone.contains(searchText.trim());
+    }).toList();
+  }
+
+  return allRows.where((row) {
+    final name = row.name?.toLowerCase() ?? '';
+    return name.contains(normalizedSearch);
+  }).toList();
+}

--- a/lib/pages/admin/account_management/admin_account_manage/admin_account_manage_model.dart
+++ b/lib/pages/admin/account_management/admin_account_manage/admin_account_manage_model.dart
@@ -1,6 +1,6 @@
+import 'dart:async';
+
 import '/backend/supabase/supabase.dart';
-import '/components/account_manage/account_manage_row/account_manage_row_widget.dart';
-import '/components/account_manage/account_manage_row_mobile/account_manage_row_mobile_widget.dart';
 import '/components/default_layout/borderline/borderline_widget.dart';
 import '/components/default_layout/headers/header_mobile/header_mobile_widget.dart';
 import '/components/default_layout/nav_bar/admin_navi_sidebar/admin_navi_sidebar_widget.dart';
@@ -209,10 +209,6 @@ class AdminAccountManageModel
   late BorderlineModel borderlineModel1;
   // Model for Borderline component.
   late BorderlineModel borderlineModel2;
-  // Model for AccountManageRow component.
-  late AccountManageRowModel accountManageRowModel1;
-  // Model for AccountManageRow component.
-  late AccountManageRowModel accountManageRowModel2;
   // Model for Borderline component.
   late BorderlineModel borderlineModel3;
   // Model for Borderline component.
@@ -235,30 +231,50 @@ class AdminAccountManageModel
   late BorderlineModel borderlineModel6;
   // Model for Borderline component.
   late BorderlineModel borderlineModel7;
-  // Model for AccountManageRow_Mobile component.
-  late AccountManageRowMobileModel accountManageRowMobileModel;
   // Model for Borderline component.
   late BorderlineModel borderlineModel8;
   // Model for Borderline component.
   late BorderlineModel borderlineModel9;
+
+  /// Data management fields.
+
+  List<PostsRow> allPosts = [];
+
+  List<PostsRow> basePosts = [];
+
+  List<AdminPostRow> adminPostRows = [];
+
+  List<PostsRow> paginatedPosts = [];
+
+  bool isLoading = false;
+
+  bool isSearching = false;
+
+  String currentSearchKeyword = '';
+
+  String? currentSearchType;
+
+  int currentPage = 1;
+
+  final int itemsPerPage = 10;
+
+  StreamSubscription<List<Map<String, dynamic>>>? postsSubscription;
+
+  StreamSubscription<List<Map<String, dynamic>>>? adminPostSubscription;
+
+  int? selectedProfessorId;
 
   @override
   void initState(BuildContext context) {
     adminNaviSidebarModel = createModel(context, () => AdminNaviSidebarModel());
     borderlineModel1 = createModel(context, () => BorderlineModel());
     borderlineModel2 = createModel(context, () => BorderlineModel());
-    accountManageRowModel1 =
-        createModel(context, () => AccountManageRowModel());
-    accountManageRowModel2 =
-        createModel(context, () => AccountManageRowModel());
     borderlineModel3 = createModel(context, () => BorderlineModel());
     borderlineModel4 = createModel(context, () => BorderlineModel());
     headerMobileModel = createModel(context, () => HeaderMobileModel());
     borderlineModel5 = createModel(context, () => BorderlineModel());
     borderlineModel6 = createModel(context, () => BorderlineModel());
     borderlineModel7 = createModel(context, () => BorderlineModel());
-    accountManageRowMobileModel =
-        createModel(context, () => AccountManageRowMobileModel());
     borderlineModel8 = createModel(context, () => BorderlineModel());
     borderlineModel9 = createModel(context, () => BorderlineModel());
   }
@@ -271,8 +287,6 @@ class AdminAccountManageModel
 
     borderlineModel1.dispose();
     borderlineModel2.dispose();
-    accountManageRowModel1.dispose();
-    accountManageRowModel2.dispose();
     borderlineModel3.dispose();
     borderlineModel4.dispose();
     headerMobileModel.dispose();
@@ -282,8 +296,9 @@ class AdminAccountManageModel
 
     borderlineModel6.dispose();
     borderlineModel7.dispose();
-    accountManageRowMobileModel.dispose();
     borderlineModel8.dispose();
     borderlineModel9.dispose();
+    postsSubscription?.cancel();
+    adminPostSubscription?.cancel();
   }
 }

--- a/lib/pages/admin/account_management/admin_account_manage/admin_account_manage_widget.dart
+++ b/lib/pages/admin/account_management/admin_account_manage/admin_account_manage_widget.dart
@@ -4,16 +4,19 @@ import '/components/account_manage/account_manage_row_mobile/account_manage_row_
 import '/components/default_layout/borderline/borderline_widget.dart';
 import '/components/default_layout/headers/header_mobile/header_mobile_widget.dart';
 import '/components/default_layout/nav_bar/admin_navi_sidebar/admin_navi_sidebar_widget.dart';
+import '/custom_code/actions/index.dart' as actions;
 import '/flutter_flow/flutter_flow_drop_down.dart';
 import '/flutter_flow/flutter_flow_icon_button.dart';
 import '/flutter_flow/flutter_flow_theme.dart';
 import '/flutter_flow/flutter_flow_util.dart';
 import '/flutter_flow/flutter_flow_widgets.dart';
 import '/flutter_flow/form_field_controller.dart';
+import 'dart:math' as math;
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:provider/provider.dart';
+import 'package:uuid/uuid.dart';
 import 'admin_account_manage_model.dart';
 export 'admin_account_manage_model.dart';
 
@@ -40,31 +43,479 @@ class _AdminAccountManageWidgetState extends State<AdminAccountManageWidget> {
 
   final scaffoldKey = GlobalKey<ScaffoldState>();
 
+  void _showSnackBar(String message) {
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text(message)),
+    );
+  }
+
+  void _showError(String message) {
+    _showSnackBar(message);
+  }
+
+  Future<List<PostsRow>> searchPostsInWidget(
+      String? searchType, String? searchText) async {
+    final keyword = searchText?.trim() ?? '';
+
+    final posts = await PostsTable().queryRows(
+      queryFn: (q) => q.order('name', ascending: true),
+    );
+    final adminRows = await AdminPostTable().queryRows(
+      queryFn: (q) => q.order('adminId', ascending: true),
+    );
+    _model.adminPostRows = adminRows;
+    final merged = _mergeWithAdminPosts(posts, adminRows: adminRows);
+
+    if (keyword.isEmpty) {
+      return merged;
+    }
+
+    final lowerKeyword = keyword.toLowerCase();
+    return merged.where((row) {
+      if (searchType == '학 번' || searchType == '연락처') {
+        final phone = row.phone ?? '';
+        return phone.contains(keyword);
+      }
+      final name = row.name?.toLowerCase() ?? '';
+      return name.contains(lowerKeyword);
+    }).toList();
+  }
+
+  String _userTypeLabel(int? userType) {
+    switch (userType) {
+      case 0:
+        return '마스터';
+      case 1:
+        return '전임';
+      case 2:
+        return '겸임';
+      case 4:
+        return '조교';
+      case 3:
+      default:
+        return '일반';
+    }
+  }
+
+  Future<void> _initializeData() async {
+    _model.isLoading = true;
+    safeSetState(() {});
+    await _loadPostsAndClasses(resetSearch: true);
+    _setupRealtimeSubscription();
+    _model.isLoading = false;
+    safeSetState(() {});
+  }
+
+  Future<void> _loadPostsAndClasses({required bool resetSearch}) async {
+    await Future.wait([
+      _loadPosts(resetSearch: resetSearch),
+      _loadClasses(),
+    ]);
+    FFAppState().usertype = 0;
+  }
+
+  Future<void> _loadPosts({required bool resetSearch}) async {
+    try {
+      final posts = await PostsTable().queryRows(
+        queryFn: (q) => q.order('name', ascending: true),
+      );
+      final adminRows = await AdminPostTable().queryRows(
+        queryFn: (q) => q.order('adminId', ascending: true),
+      );
+      _model.adminPostRows = adminRows;
+      _model.basePosts = posts.map((row) {
+        final cloned = PostsRow(Map<String, dynamic>.from(row.data));
+        cloned.userType = cloned.userType ?? 3;
+        cloned.position = _userTypeLabel(cloned.userType);
+        return cloned;
+      }).toList();
+      final merged = _mergeWithAdminPosts(_model.basePosts);
+      if (resetSearch) {
+        _model.isSearching = false;
+        _model.currentSearchKeyword = '';
+      }
+      _applyPostsData(merged,
+          resetPage: resetSearch, preserveSearch: !resetSearch);
+    } catch (e) {
+      _showError('데이터 로드 실패: $e');
+      _model.basePosts = [];
+      _model.adminPostRows = [];
+      _model.prfoutput = [];
+      _model.paginatedPosts = [];
+    }
+  }
+
+  Future<void> _loadClasses() async {
+    try {
+      _model.classSelectedOnload = await ClassTable().queryRows(
+        queryFn: (q) => q,
+      );
+      _applyClassFilters();
+    } catch (e) {
+      _showError('강의 정보 로드 실패: $e');
+      _model.classSelectedOnload = [];
+      _model.classOnload = [];
+    }
+  }
+
+  void _applyPostsData(List<PostsRow> posts,
+      {bool resetPage = false, bool preserveSearch = true}) {
+    final sorted = [...posts]
+      ..sort(
+        (a, b) => (a.name ?? '').compareTo(b.name ?? ''),
+      );
+    _model.allPosts = sorted;
+    final previousSelection = _model.selectedProfessorId;
+    if (!preserveSearch) {
+      _model.isSearching = false;
+      _model.currentSearchKeyword = '';
+    }
+    final filtered = _filterPosts(sorted);
+    _model.prfoutput = filtered;
+    if (resetPage) {
+      _model.currentPage = 1;
+    }
+    final selectedId = previousSelection != null &&
+            filtered.any((row) => row.id == previousSelection)
+        ? previousSelection
+        : filtered.firstOrNull?.id ?? sorted.firstOrNull?.id;
+    _model.selectedProfessorId = selectedId;
+    final selectedRow = selectedId == null
+        ? null
+        : filtered
+                .where((row) => row.id == selectedId)
+                .firstOrNull ??
+            sorted.where((row) => row.id == selectedId).firstOrNull;
+    _model.profeesorName = valueOrDefault<String>(
+      selectedRow?.name ?? filtered.firstOrNull?.name ?? sorted.firstOrNull?.name,
+      '교수 이름',
+    );
+    _updatePagination(resetPage: resetPage);
+    _applyClassFilters();
+  }
+
+  List<PostsRow> _filterPosts(List<PostsRow> source) {
+    if (!_model.isSearching || _model.currentSearchKeyword.isEmpty) {
+      return List<PostsRow>.from(source);
+    }
+    final keyword = _model.currentSearchKeyword;
+    final lowerKeyword = keyword.toLowerCase();
+    return source
+        .where(
+            (row) => (row.name ?? '').toLowerCase().contains(lowerKeyword))
+        .toList();
+  }
+
+  List<PostsRow> _mergeWithAdminPosts(List<PostsRow> source,
+      {List<AdminPostRow>? adminRows}) {
+    if (source.isEmpty) {
+      return [];
+    }
+    final effectiveAdminRows = adminRows ?? _model.adminPostRows;
+    if (effectiveAdminRows.isEmpty) {
+      return source.map((row) {
+        final cloned = PostsRow(Map<String, dynamic>.from(row.data));
+        final resolvedUserType = cloned.userType ?? 3;
+        cloned.userType = resolvedUserType;
+        cloned.position = _userTypeLabel(resolvedUserType);
+        if (resolvedUserType == 0 || resolvedUserType == 1) {
+          final currentLevel = cloned.permissionLevel ?? 1;
+          if (currentLevel < 2) {
+            cloned.permissionLevel = 2;
+          }
+        }
+        return cloned;
+      }).toList();
+    }
+    final adminMap = {
+      for (final admin in effectiveAdminRows)
+        admin.adminId.toLowerCase(): admin,
+    };
+    return source.map((row) {
+      final cloned = PostsRow(Map<String, dynamic>.from(row.data));
+      final emailKey = (cloned.email ?? '').toLowerCase();
+      final admin = adminMap[emailKey];
+      if (admin != null) {
+        final adminName = admin.name;
+        if (adminName != null && adminName.isNotEmpty) {
+          cloned.name = adminName;
+        }
+        final adminRole = admin.role;
+        final existingLevel = cloned.permissionLevel ?? 1;
+        var roleLevel = existingLevel;
+        if (adminRole.isNotEmpty) {
+          roleLevel = _permissionLevelFromRole(adminRole);
+        }
+        if (roleLevel < 2) {
+          roleLevel = 2;
+        }
+        if (roleLevel > existingLevel) {
+          cloned.permissionLevel = roleLevel;
+        }
+        final adminUserType = admin.userType;
+        if (adminUserType != null) {
+          cloned.userType = adminUserType;
+        }
+        if (cloned.email == null || cloned.email!.isEmpty) {
+          cloned.email = admin.adminId;
+        }
+      }
+      final resolvedUserType = cloned.userType ?? 3;
+      cloned.userType = resolvedUserType;
+      cloned.position = _userTypeLabel(resolvedUserType);
+      if (resolvedUserType == 0 || resolvedUserType == 1) {
+        final currentLevel = cloned.permissionLevel ?? 1;
+        if (currentLevel < 2) {
+          cloned.permissionLevel = 2;
+        }
+      }
+      return cloned;
+    }).toList();
+  }
+
+  int _permissionLevelFromRole(String role) {
+    final normalized = role.toLowerCase().trim();
+    if (normalized.contains('master') ||
+        normalized.contains('admin') ||
+        normalized.contains('관리')) {
+      return 2;
+    }
+    return 1;
+  }
+
+  String _roleFromPermissionLevel(int level) => level >= 2 ? 'MASTER' : 'MEMBER';
+
+  void _updateBasePostRow(int postId, Map<String, dynamic> updatedData) {
+    if (_model.basePosts.isEmpty) {
+      return;
+    }
+    final index = _model.basePosts.indexWhere((row) => row.id == postId);
+    if (index == -1) {
+      return;
+    }
+    final baseRow = _model.basePosts[index];
+    updatedData.forEach((key, value) {
+      baseRow.setField(key, value);
+    });
+  }
+
+  void _refreshMergedPosts() {
+    if (_model.basePosts.isEmpty) {
+      return;
+    }
+    final merged = _mergeWithAdminPosts(_model.basePosts);
+    _applyPostsData(merged, preserveSearch: true);
+    safeSetState(() {});
+  }
+
+  Future<void> _ensureAdminPostRecord(
+    PostsRow post,
+    Map<String, dynamic> updatedData,
+  ) async {
+    final email = post.email;
+    if (email == null || email.isEmpty) {
+      return;
+    }
+    final effectiveName =
+        (updatedData['name'] as String?) ?? post.name ?? '';
+    final effectivePermission =
+        (updatedData['permission_level'] as int?) ??
+            post.permissionLevel ??
+            1;
+    final effectiveUserType =
+        (updatedData['user_type'] as int?) ?? post.userType ?? 0;
+    final roleValue = _roleFromPermissionLevel(effectivePermission);
+
+    final existing = await AdminPostTable().queryRows(
+      queryFn: (q) => q.eq('adminId', email).limit(1),
+    );
+
+    if (existing.isEmpty) {
+      final inserted = await AdminPostTable().insert({
+        'adminId': email,
+        'AdminInfo': const Uuid().v4(),
+        'name': effectiveName,
+        'user_type': effectiveUserType,
+        'role': roleValue,
+      });
+      _model.adminPostRows = [
+        ..._model.adminPostRows
+            .where((row) => row.adminId.toLowerCase() != email.toLowerCase()),
+        inserted,
+      ];
+    } else {
+      final adminRow = existing.first;
+      final updatePayload = {
+        'name': effectiveName,
+        'user_type': effectiveUserType,
+        'role': roleValue,
+      };
+      await AdminPostTable().update(
+        data: updatePayload,
+        matchingRows: (rows) => rows.eq('id', adminRow.id),
+      );
+      adminRow.name = effectiveName;
+      adminRow.userType = effectiveUserType;
+      adminRow.role = roleValue;
+    }
+  }
+
+  Future<void> _handlePostEdit(
+    PostsRow post,
+    Map<String, dynamic> updatedData,
+  ) async {
+    try {
+      await _ensureAdminPostRecord(post, updatedData);
+      if (updatedData.isNotEmpty) {
+        _updateBasePostRow(post.id, updatedData);
+      }
+      _refreshMergedPosts();
+    } catch (e) {
+      _showError('관리자 정보 동기화 실패: $e');
+    }
+  }
+
+  void _updatePagination({bool resetPage = false}) {
+    final data = List<PostsRow>.from(_model.prfoutput ?? []);
+    if (resetPage) {
+      _model.currentPage = 1;
+    }
+    final totalCount = data.length;
+    final totalPages = totalCount == 0
+        ? 1
+        : ((totalCount - 1) ~/ _model.itemsPerPage) + 1;
+    if (_model.currentPage > totalPages) {
+      _model.currentPage = totalPages;
+    }
+    if (_model.currentPage < 1) {
+      _model.currentPage = 1;
+    }
+    final startIndex = (_model.currentPage - 1) * _model.itemsPerPage;
+    final endIndex = math.min(startIndex + _model.itemsPerPage, totalCount);
+    if (startIndex < 0 || startIndex >= totalCount) {
+      _model.paginatedPosts = [];
+      return;
+    }
+    _model.paginatedPosts = data.sublist(startIndex, endIndex);
+  }
+
+  int get _totalPages {
+    final total = _model.prfoutput?.length ?? 0;
+    if (total == 0) {
+      return 1;
+    }
+    return ((total - 1) ~/ _model.itemsPerPage) + 1;
+  }
+
+  String? _validateSearchInput(String? value) {
+    if (value == null || value.trim().isEmpty) {
+      return '검색어를 입력해주세요';
+    }
+    return null;
+  }
+
+  Future<void> _refreshData() async {
+    _model.isLoading = true;
+    safeSetState(() {});
+    await _loadPostsAndClasses(resetSearch: false);
+    _model.isLoading = false;
+    safeSetState(() {});
+  }
+
+  void _applyClassFilters() {
+    if (_model.classSelectedOnload == null) {
+      return;
+    }
+    _model.classOnload = _model.classSelectedOnload!
+        .where((e) =>
+            e.year == _model.years &&
+            e.semester == _model.semester &&
+            (_model.selectedProfessorId == null ||
+                e.professorId == _model.selectedProfessorId))
+        .toList()
+        .cast<ClassRow>();
+  }
+
+  void _setupRealtimeSubscription() {
+    _model.postsSubscription?.cancel();
+    _model.postsSubscription = Supabase.instance.client
+        .from('posts')
+        .stream(primaryKey: ['id'])
+        .listen((data) {
+      final rows = data.map((row) => PostsRow(row)).toList();
+      _model.basePosts = rows
+          .map((row) => PostsRow(Map<String, dynamic>.from(row.data)))
+          .toList();
+      final merged = _mergeWithAdminPosts(_model.basePosts);
+      _applyPostsData(merged, preserveSearch: true);
+      safeSetState(() {});
+    }, onError: (error) {
+      _showError('실시간 데이터 수신 실패: $error');
+    });
+    _model.adminPostSubscription?.cancel();
+    _model.adminPostSubscription = Supabase.instance.client
+        .from('admin_post')
+        .stream(primaryKey: ['id'])
+        .listen((data) {
+      _model.adminPostRows = data.map((row) => AdminPostRow(row)).toList();
+      if (_model.basePosts.isEmpty) {
+        return;
+      }
+      final merged = _mergeWithAdminPosts(_model.basePosts);
+      _applyPostsData(merged, preserveSearch: true);
+      safeSetState(() {});
+    }, onError: (error) {
+      _showError('관리자 계정 실시간 수신 실패: $error');
+    });
+  }
+
+  void _handlePageChange(bool isNext) {
+    if (isNext) {
+      if (_model.currentPage < _totalPages) {
+        _model.currentPage += 1;
+        _updatePagination();
+        safeSetState(() {});
+      }
+    } else {
+      if (_model.currentPage > 1) {
+        _model.currentPage -= 1;
+        _updatePagination();
+        safeSetState(() {});
+      }
+    }
+  }
+
   @override
   void initState() {
     super.initState();
     _model = createModel(context, () => AdminAccountManageModel());
 
-    // On page load action.
     SchedulerBinding.instance.addPostFrameCallback((_) async {
-      _model.prfoutput = await PostsTable().queryRows(
-        queryFn: (q) => q,
-      );
-      _model.profeesorName = valueOrDefault<String>(
-        _model.prfoutput?.firstOrNull?.name,
-        '교수 이름',
-      );
-      safeSetState(() {});
-      _model.classSelectedOnload = await ClassTable().queryRows(
-        queryFn: (q) => q,
-      );
-      _model.classOnload = _model.classSelectedOnload!
-          .where((e) =>
-              (e.year == _model.years) && (e.semester == _model.semester))
-          .toList()
-          .toList()
-          .cast<ClassRow>();
-      safeSetState(() {});
+      try {
+        _model.prfoutput = await PostsTable().queryRows(
+          queryFn: (q) => q.order('name', ascending: true),
+        );
+
+        _model.profeesorName =
+            _model.prfoutput?.firstOrNull?.name ?? '교수 이름';
+
+        _model.classSelectedOnload = await ClassTable().queryRows(
+          queryFn: (q) => q,
+        );
+
+        _model.classOnload = _model.classSelectedOnload!
+            .where((e) => (e.year == _model.years) && (e.semester == _model.semester))
+            .toList()
+            .cast<ClassRow>();
+      } catch (e) {
+        print('초기화 에러: $e');
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('데이터 로드 실패: $e')),
+        );
+        _model.prfoutput = [];
+        _model.classOnload = [];
+      }
+
       FFAppState().usertype = 0;
       safeSetState(() {});
     });
@@ -74,6 +525,13 @@ class _AdminAccountManageWidgetState extends State<AdminAccountManageWidget> {
 
     _model.textController2 ??= TextEditingController();
     _model.textFieldFocusNode2 ??= FocusNode();
+
+    _model.dropDownValue ??= '이 름';
+    _model.currentSearchType ??= _model.dropDownValue;
+    _model.textController1Validator =
+        (context, value) => _validateSearchInput(value);
+    _model.textController2Validator =
+        (context, value) => _validateSearchInput(value);
 
     WidgetsBinding.instance.addPostFrameCallback((_) => safeSetState(() {}));
   }
@@ -953,23 +1411,24 @@ class _AdminAccountManageWidgetState extends State<AdminAccountManageWidget> {
                                                       controller: _model
                                                               .dropDownValueController ??=
                                                           FormFieldController<
-                                                              String>(null),
+                                                              String>(_model
+                                                                  .dropDownValue ??
+                                                              '이 름'),
                                                       options: [
                                                         FFLocalizations.of(
                                                                 context)
                                                             .getText(
                                                           'n15kxnyz' /* 이 름 */,
-                                                        ),
-                                                        FFLocalizations.of(
-                                                                context)
-                                                            .getText(
-                                                          'dyvx85vc' /* 학 번 */,
                                                         )
                                                       ],
-                                                      onChanged: (val) =>
-                                                          safeSetState(() =>
-                                                              _model.dropDownValue =
-                                                                  val),
+                                                      onChanged: (val) {
+                                                        safeSetState(() {
+                                                          _model.dropDownValue =
+                                                              val;
+                                                          _model.currentSearchType =
+                                                              val;
+                                                        });
+                                                      },
                                                       width: 200.0,
                                                       height: 40.0,
                                                       textStyle:
@@ -1049,6 +1508,12 @@ class _AdminAccountManageWidgetState extends State<AdminAccountManageWidget> {
                                                       decoration:
                                                           InputDecoration(
                                                         isDense: true,
+                                                        contentPadding:
+                                                            const EdgeInsets
+                                                                .symmetric(
+                                                          horizontal: 12.0,
+                                                          vertical: 10.0,
+                                                        ),
                                                         labelStyle:
                                                             FlutterFlowTheme.of(
                                                                     context)
@@ -1227,15 +1692,77 @@ class _AdminAccountManageWidgetState extends State<AdminAccountManageWidget> {
                                                 Expanded(
                                                   flex: 1,
                                                   child: FFButtonWidget(
-                                                    onPressed: () {
-                                                      print(
-                                                          'Button pressed ...');
+                                                    onPressed: () async {
+                                                      try {
+                                                        final searchText =
+                                                            _model.textController1
+                                                                .text
+                                                                .trim();
+
+                                                        final results =
+                                                            await actions.searchPosts(
+                                                          _model.dropDownValue ??
+                                                              '이 름',
+                                                          searchText,
+                                                        );
+                                                        List<PostsRow>
+                                                            mergedResults;
+                                                        if (results.isEmpty) {
+                                                          mergedResults =
+                                                              await searchPostsInWidget(
+                                                            _model.dropDownValue ??
+                                                                '이 름',
+                                                            searchText,
+                                                          );
+                                                        } else {
+                                                          mergedResults =
+                                                              _mergeWithAdminPosts(
+                                                                  results);
+                                                        }
+
+                                                        _model.isSearching =
+                                                            searchText
+                                                                .isNotEmpty;
+                                                        _model
+                                                                .currentSearchKeyword =
+                                                            searchText;
+                                                        _model.currentSearchType =
+                                                            _model.dropDownValue ??
+                                                                '이 름';
+                                                        _model.prfoutput =
+                                                            mergedResults;
+                                                        _model.profeesorName =
+                                                            mergedResults
+                                                                    .firstOrNull
+                                                                    ?.name ??
+                                                                '교수 이름';
+                                                        _updatePagination(
+                                                            resetPage: true);
+                                                        safeSetState(() {});
+
+                                                        if (_model.prfoutput
+                                                                ?.isEmpty ??
+                                                            true) {
+                                                          ScaffoldMessenger.of(
+                                                                  context)
+                                                              .showSnackBar(
+                                                            const SnackBar(
+                                                              content: Text(
+                                                                  '검색 결과가 없습니다.'),
+                                                            ),
+                                                          );
+                                                        }
+                                                      } catch (e) {
+                                                        ScaffoldMessenger.of(
+                                                                context)
+                                                            .showSnackBar(
+                                                          SnackBar(
+                                                              content: Text(
+                                                                  '검색 중 오류가 발생했습니다: $e')),
+                                                        );
+                                                      }
                                                     },
-                                                    text: FFLocalizations.of(
-                                                            context)
-                                                        .getText(
-                                                      'o13eae5a' /* 학생 검색 */,
-                                                    ),
+                                                    text: '관리자 계정 검색',
                                                     options: FFButtonOptions(
                                                       height: 40.0,
                                                       padding:
@@ -1621,25 +2148,52 @@ class _AdminAccountManageWidgetState extends State<AdminAccountManageWidget> {
                                         child: Column(
                                           mainAxisSize: MainAxisSize.max,
                                           children: [
-                                            wrapWithModel(
-                                              model:
-                                                  _model.accountManageRowModel1,
-                                              updateCallback: () =>
-                                                  safeSetState(() {}),
-                                              child: AccountManageRowWidget(
-                                                confirmEdit: (confirm) async {},
+                                            if ((_model.paginatedPosts).isEmpty)
+                                              Padding(
+                                                padding: EdgeInsetsDirectional
+                                                    .fromSTEB(
+                                                        20.0, 20.0, 20.0, 20.0),
+                                                child: Text(
+                                                  '표시할 데이터가 없습니다.',
+                                                  style: FlutterFlowTheme.of(
+                                                          context)
+                                                      .bodyMedium,
+                                                ),
                                               ),
-                                            ),
-                                            wrapWithModel(
-                                              model:
-                                                  _model.accountManageRowModel2,
-                                              updateCallback: () =>
-                                                  safeSetState(() {}),
-                                              child: AccountManageRowWidget(
-                                                isEditing: true,
-                                                confirmEdit: (confirm) async {},
-                                              ),
-                                            ),
+                                            ..._model.paginatedPosts
+                                                .map(
+                                                  (post) => Padding(
+                                                    padding:
+                                                        EdgeInsetsDirectional
+                                                            .fromSTEB(
+                                                                0.0,
+                                                                0.0,
+                                                                0.0,
+                                                                10.0),
+                                                    child:
+                                                        AccountManageRowWidget(
+                                                      key: ValueKey(
+                                                          'account_row_${post.id}'),
+                                                      post: post,
+                                                      confirmEdit:
+                                                          (confirm, data) async {
+                                                        if (confirm) {
+                                                          await _handlePostEdit(
+                                                            post,
+                                                            data,
+                                                          );
+                                                        }
+                                                      },
+                                                      onSelected: () {
+                                                        _model.selectedProfessorId =
+                                                            post.id;
+                                                        _applyClassFilters();
+                                                        safeSetState(() {});
+                                                      },
+                                                    ),
+                                                  ),
+                                                )
+                                                .toList(),
                                           ],
                                         ),
                                       ),
@@ -1662,8 +2216,79 @@ class _AdminAccountManageWidgetState extends State<AdminAccountManageWidget> {
                                           child: Row(
                                             mainAxisSize: MainAxisSize.max,
                                             mainAxisAlignment:
-                                                MainAxisAlignment.end,
+                                                MainAxisAlignment.spaceBetween,
                                             children: [
+                                              Row(
+                                                mainAxisSize: MainAxisSize.min,
+                                                children: [
+                                                  IconButton(
+                                                    icon: Icon(
+                                                      Icons.chevron_left,
+                                                      color: _model.currentPage >
+                                                              1
+                                                          ? Color(0xFF666666)
+                                                          : Color(0xFFCCCCCC),
+                                                    ),
+                                                    onPressed: _model
+                                                                .currentPage >
+                                                            1
+                                                        ? () =>
+                                                            _handlePageChange(
+                                                                false)
+                                                        : null,
+                                                  ),
+                                                  Text(
+                                                    '${_model.currentPage} / ${_totalPages}',
+                                                    style: FlutterFlowTheme.of(
+                                                            context)
+                                                        .bodyMedium
+                                                        .override(
+                                                          font: GoogleFonts
+                                                              .openSans(
+                                                            fontWeight:
+                                                                FlutterFlowTheme.of(
+                                                                        context)
+                                                                    .bodyMedium
+                                                                    .fontWeight,
+                                                            fontStyle:
+                                                                FlutterFlowTheme.of(
+                                                                        context)
+                                                                    .bodyMedium
+                                                                    .fontStyle,
+                                                          ),
+                                                          color:
+                                                              Color(0xFF666666),
+                                                          letterSpacing: 0.0,
+                                                          fontWeight:
+                                                              FlutterFlowTheme.of(
+                                                                      context)
+                                                                  .bodyMedium
+                                                                  .fontWeight,
+                                                          fontStyle:
+                                                              FlutterFlowTheme.of(
+                                                                      context)
+                                                                  .bodyMedium
+                                                                  .fontStyle,
+                                                        ),
+                                                  ),
+                                                  IconButton(
+                                                    icon: Icon(
+                                                      Icons.chevron_right,
+                                                      color: _model.currentPage <
+                                                              _totalPages
+                                                          ? Color(0xFF666666)
+                                                          : Color(0xFFCCCCCC),
+                                                    ),
+                                                    onPressed: _model
+                                                                .currentPage <
+                                                            _totalPages
+                                                        ? () =>
+                                                            _handlePageChange(
+                                                                true)
+                                                        : null,
+                                                  ),
+                                                ],
+                                              ),
                                               RichText(
                                                 textScaler:
                                                     MediaQuery.of(context)
@@ -1705,37 +2330,17 @@ class _AdminAccountManageWidgetState extends State<AdminAccountManageWidget> {
                                                               ),
                                                     ),
                                                     TextSpan(
-                                                      text: FFLocalizations.of(
-                                                              context)
-                                                          .getText(
-                                                        '3kswy82q' /*  10 */,
-                                                      ),
+                                                      text:
+                                                          ' ${_model.prfoutput?.length ?? 0} ',
                                                       style:
                                                           FlutterFlowTheme.of(
                                                                   context)
                                                               .bodyMedium
                                                               .override(
-                                                                font: GoogleFonts
-                                                                    .openSans(
-                                                                  fontWeight: FlutterFlowTheme.of(
-                                                                          context)
-                                                                      .bodyMedium
-                                                                      .fontWeight,
-                                                                  fontStyle: FlutterFlowTheme.of(
-                                                                          context)
-                                                                      .bodyMedium
-                                                                      .fontStyle,
-                                                                ),
+                                                                fontFamily:
+                                                                    'Open Sans',
                                                                 letterSpacing:
                                                                     0.0,
-                                                                fontWeight: FlutterFlowTheme.of(
-                                                                        context)
-                                                                    .bodyMedium
-                                                                    .fontWeight,
-                                                                fontStyle: FlutterFlowTheme.of(
-                                                                        context)
-                                                                    .bodyMedium
-                                                                    .fontStyle,
                                                                 decoration:
                                                                     TextDecoration
                                                                         .underline,
@@ -1830,6 +2435,19 @@ class _AdminAccountManageWidgetState extends State<AdminAccountManageWidget> {
                 ],
               ),
             ),
+            if (_model.isLoading)
+              Positioned.fill(
+                child: Container(
+                  color: Colors.black26,
+                  child: Center(
+                    child: CircularProgressIndicator(
+                      valueColor: AlwaysStoppedAnimation<Color>(
+                        Color(0xFF284E75),
+                      ),
+                    ),
+                  ),
+                ),
+              ),
             if (responsiveVisibility(
               context: context,
               tabletLandscape: false,
@@ -2211,8 +2829,42 @@ class _AdminAccountManageWidgetState extends State<AdminAccountManageWidget> {
                                 color: Color(0xFF666666),
                                 size: 24.0,
                               ),
-                              onPressed: () {
-                                print('IconButton pressed ...');
+                              onPressed: () async {
+                                showDialog(
+                                  context: context,
+                                  barrierDismissible: false,
+                                  builder: (context) =>
+                                      const Center(child: CircularProgressIndicator()),
+                                );
+
+                                try {
+                                  _model.prfoutput = await PostsTable().queryRows(
+                                    queryFn: (q) => q.order('name', ascending: true),
+                                  );
+
+                                  _model.classSelectedOnload =
+                                      await ClassTable().queryRows(
+                                    queryFn: (q) => q,
+                                  );
+
+                                  _model.classOnload = _model.classSelectedOnload!
+                                      .where((e) =>
+                                          e.year == _model.years &&
+                                          e.semester == _model.semester)
+                                      .toList()
+                                      .cast<ClassRow>();
+                                } catch (e) {
+                                  ScaffoldMessenger.of(context).showSnackBar(
+                                    SnackBar(content: Text('새로고침 실패: $e')),
+                                  );
+                                } finally {
+                                  Navigator.pop(context);
+                                }
+
+                                _model.profeesorName =
+                                    _model.prfoutput?.firstOrNull?.name ?? '교수 이름';
+                                _updatePagination(resetPage: true);
+                                safeSetState(() {});
                               },
                             ),
                           ],
@@ -2246,6 +2898,11 @@ class _AdminAccountManageWidgetState extends State<AdminAccountManageWidget> {
                                   obscureText: false,
                                   decoration: InputDecoration(
                                     isDense: true,
+                                    contentPadding:
+                                        const EdgeInsets.symmetric(
+                                      horizontal: 12.0,
+                                      vertical: 10.0,
+                                    ),
                                     labelStyle: FlutterFlowTheme.of(context)
                                         .labelMedium
                                         .override(
@@ -2374,12 +3031,53 @@ class _AdminAccountManageWidgetState extends State<AdminAccountManageWidget> {
                             Flexible(
                               flex: 1,
                               child: FFButtonWidget(
-                                onPressed: () {
-                                  print('Button pressed ...');
+                                onPressed: () async {
+                                  try {
+                                    final searchText =
+                                        _model.textController2.text.trim();
+
+                                    final results = await actions.searchPosts(
+                                      '이 름',
+                                      searchText,
+                                    );
+                                    List<PostsRow> mergedResults;
+                                    if (results.isEmpty) {
+                                      mergedResults =
+                                          await searchPostsInWidget(
+                                        '이 름',
+                                        searchText,
+                                      );
+                                    } else {
+                                      mergedResults =
+                                          _mergeWithAdminPosts(results);
+                                    }
+
+                                    _model.isSearching = searchText.isNotEmpty;
+                                    _model.currentSearchKeyword = searchText;
+                                    _model.currentSearchType = '이 름';
+                                    _model.prfoutput = mergedResults;
+                                    _model.profeesorName = mergedResults
+                                            .firstOrNull
+                                            ?.name ??
+                                        '교수 이름';
+                                    _updatePagination(resetPage: true);
+                                    safeSetState(() {});
+
+                                    if (_model.prfoutput?.isEmpty ?? true) {
+                                      ScaffoldMessenger.of(context).showSnackBar(
+                                        const SnackBar(
+                                          content: Text('검색 결과가 없습니다.'),
+                                        ),
+                                      );
+                                    }
+                                  } catch (e) {
+                                    ScaffoldMessenger.of(context).showSnackBar(
+                                      SnackBar(
+                                          content: Text('검색 중 오류가 발생했습니다: $e')),
+                                    );
+                                  }
                                 },
-                                text: FFLocalizations.of(context).getText(
-                                  'byp1bfcg' /* 교수 검색 */,
-                                ),
+                                  text: '관리자 계정 검색',
                                 options: FFButtonOptions(
                                   height: 30.0,
                                   padding: EdgeInsetsDirectional.fromSTEB(
@@ -2650,26 +3348,53 @@ class _AdminAccountManageWidgetState extends State<AdminAccountManageWidget> {
                                     MediaQuery.sizeOf(context).height * 0.7,
                               ),
                               decoration: BoxDecoration(),
-                              child: Column(
-                                mainAxisSize: MainAxisSize.max,
-                                children: [
-                                  ListView(
-                                    padding: EdgeInsets.zero,
-                                    shrinkWrap: true,
-                                    scrollDirection: Axis.vertical,
-                                    children: [
-                                      wrapWithModel(
-                                        model:
-                                            _model.accountManageRowMobileModel,
-                                        updateCallback: () =>
-                                            safeSetState(() {}),
-                                        child: AccountManageRowMobileWidget(
-                                          confirmEdit: (confirm) async {},
+                              child: SingleChildScrollView(
+                                child: Column(
+                                  mainAxisSize: MainAxisSize.max,
+                                  children: [
+                                    if ((_model.paginatedPosts).isEmpty)
+                                      Padding(
+                                        padding: EdgeInsetsDirectional.fromSTEB(
+                                            10.0, 20.0, 10.0, 20.0),
+                                        child: Text(
+                                          '표시할 데이터가 없습니다.',
+                                          style:
+                                              FlutterFlowTheme.of(context)
+                                                  .bodyMedium,
                                         ),
                                       ),
-                                    ].divide(SizedBox(height: 10.0)),
-                                  ),
-                                ],
+                                    ..._model.paginatedPosts
+                                        .map(
+                                          (post) => Padding(
+                                            padding: EdgeInsetsDirectional
+                                                .fromSTEB(
+                                                    0.0, 0.0, 0.0, 10.0),
+                                            child:
+                                                AccountManageRowMobileWidget(
+                                              key: ValueKey(
+                                                  'account_row_mobile_${post.id}'),
+                                              post: post,
+                                              confirmEdit:
+                                                  (confirm, data) async {
+                                                if (confirm) {
+                                                  await _handlePostEdit(
+                                                    post,
+                                                    data,
+                                                  );
+                                                }
+                                              },
+                                              onSelected: () {
+                                                _model.selectedProfessorId =
+                                                    post.id;
+                                                _applyClassFilters();
+                                                safeSetState(() {});
+                                              },
+                                            ),
+                                          ),
+                                        )
+                                        .toList(),
+                                  ],
+                                ),
                               ),
                             ),
                             wrapWithModel(
@@ -2691,8 +3416,82 @@ class _AdminAccountManageWidgetState extends State<AdminAccountManageWidget> {
                                       10.0, 0.0, 10.0, 0.0),
                                   child: Row(
                                     mainAxisSize: MainAxisSize.max,
-                                    mainAxisAlignment: MainAxisAlignment.end,
+                                    mainAxisAlignment:
+                                        MainAxisAlignment.spaceBetween,
                                     children: [
+                                      Row(
+                                        mainAxisSize: MainAxisSize.min,
+                                        children: [
+                                          IconButton(
+                                            icon: Icon(
+                                              Icons.chevron_left,
+                                              color: _model.currentPage > 1
+                                                  ? Color(0xFF666666)
+                                                  : Color(0xFFCCCCCC),
+                                            ),
+                                            iconSize: 20.0,
+                                            padding: EdgeInsets.zero,
+                                            onPressed: _model.currentPage > 1
+                                                ? () =>
+                                                    _handlePageChange(false)
+                                                : null,
+                                          ),
+                                          Padding(
+                                            padding:
+                                                EdgeInsetsDirectional.fromSTEB(
+                                                    4.0, 0.0, 4.0, 0.0),
+                                            child: Text(
+                                              '${_model.currentPage} / ${_totalPages}',
+                                              style:
+                                                  FlutterFlowTheme.of(context)
+                                                      .bodyMedium
+                                                      .override(
+                                                        font: GoogleFonts
+                                                            .openSans(
+                                                          fontWeight:
+                                                              FlutterFlowTheme.of(
+                                                                      context)
+                                                                  .bodyMedium
+                                                                  .fontWeight,
+                                                          fontStyle:
+                                                              FlutterFlowTheme.of(
+                                                                      context)
+                                                                  .bodyMedium
+                                                                  .fontStyle,
+                                                        ),
+                                                        letterSpacing: 0.0,
+                                                        fontWeight:
+                                                            FlutterFlowTheme.of(
+                                                                    context)
+                                                                .bodyMedium
+                                                                .fontWeight,
+                                                        fontStyle:
+                                                            FlutterFlowTheme.of(
+                                                                    context)
+                                                                .bodyMedium
+                                                                .fontStyle,
+                                                      ),
+                                            ),
+                                          ),
+                                          IconButton(
+                                            icon: Icon(
+                                              Icons.chevron_right,
+                                              color: _model.currentPage <
+                                                      _totalPages
+                                                  ? Color(0xFF666666)
+                                                  : Color(0xFFCCCCCC),
+                                            ),
+                                            iconSize: 20.0,
+                                            padding: EdgeInsets.zero,
+                                            onPressed:
+                                                _model.currentPage < _totalPages
+                                                    ? () => _handlePageChange(
+                                                          true,
+                                                        )
+                                                    : null,
+                                          ),
+                                        ],
+                                      ),
                                       RichText(
                                         textScaler:
                                             MediaQuery.of(context).textScaler,
@@ -2733,39 +3532,16 @@ class _AdminAccountManageWidgetState extends State<AdminAccountManageWidget> {
                                                   ),
                                             ),
                                             TextSpan(
-                                              text: FFLocalizations.of(context)
-                                                  .getText(
-                                                'semk81sv' /* 10 */,
-                                              ),
+                                              text:
+                                                  ' ${_model.prfoutput?.length ?? 0} ',
                                               style: FlutterFlowTheme.of(
                                                       context)
                                                   .bodyMedium
                                                   .override(
-                                                    font: GoogleFonts.openSans(
-                                                      fontWeight:
-                                                          FlutterFlowTheme.of(
-                                                                  context)
-                                                              .bodyMedium
-                                                              .fontWeight,
-                                                      fontStyle:
-                                                          FlutterFlowTheme.of(
-                                                                  context)
-                                                              .bodyMedium
-                                                              .fontStyle,
-                                                    ),
+                                                    fontFamily: 'Open Sans',
                                                     letterSpacing: 0.0,
-                                                    fontWeight:
-                                                        FlutterFlowTheme.of(
-                                                                context)
-                                                            .bodyMedium
-                                                            .fontWeight,
-                                                    fontStyle:
-                                                        FlutterFlowTheme.of(
-                                                                context)
-                                                            .bodyMedium
-                                                            .fontStyle,
-                                                    decoration: TextDecoration
-                                                        .underline,
+                                                    decoration:
+                                                        TextDecoration.underline,
                                                   ),
                                             ),
                                             TextSpan(

--- a/lib/pages/auth/login_page/login_page_widget.dart
+++ b/lib/pages/auth/login_page/login_page_widget.dart
@@ -1498,7 +1498,7 @@ class _LoginPageWidgetState extends State<LoginPageWidget> {
                                                                         .queryRows(
                                                                   queryFn: (q) =>
                                                                       q.eqOrNull(
-                                                                    'user_email',
+                                                                    'email',
                                                                     _model
                                                                         .emailTextFieldTextController
                                                                         .text,
@@ -1514,7 +1514,7 @@ class _LoginPageWidgetState extends State<LoginPageWidget> {
                                                                     _model
                                                                         .userTypeOutput
                                                                         ?.firstOrNull
-                                                                        ?.userType,
+                                                                        ?.permissionLevel,
                                                                     0,
                                                                   );
                                                                   _model.emailField =

--- a/lib/pages/auth/register_page/register_page_widget.dart
+++ b/lib/pages/auth/register_page/register_page_widget.dart
@@ -3229,33 +3229,6 @@ class _RegisterPageWidgetState extends State<RegisterPageWidget>
                                                                 _model.insertpfr =
                                                                     await PostsTable()
                                                                         .insert({
-                                                                  'user_type':
-                                                                      valueOrDefault<
-                                                                          int>(
-                                                                    _model
-                                                                        .validationquery
-                                                                        ?.prfType,
-                                                                    2,
-                                                                  ),
-                                                                  'university':
-                                                                      valueOrDefault<
-                                                                          String>(
-                                                                    _model
-                                                                        .universityDropdownValue,
-                                                                    '학교이름',
-                                                                  ),
-                                                                  'user_alias':
-                                                                      valueOrDefault<
-                                                                          String>(
-                                                                    _model
-                                                                        .validationquery
-                                                                        ?.userAlias,
-                                                                    '교수 유형',
-                                                                  ),
-                                                                  'user_email':
-                                                                      currentUserEmail,
-                                                                  'user':
-                                                                      currentUserUid,
                                                                   'name':
                                                                       valueOrDefault<
                                                                           String>(
@@ -3264,6 +3237,26 @@ class _RegisterPageWidgetState extends State<RegisterPageWidget>
                                                                         .text,
                                                                     '교수님 이름',
                                                                   ),
+                                                                  'position':
+                                                                      valueOrDefault<
+                                                                          String>(
+                                                                    _model
+                                                                        .validationquery
+                                                                        ?.userAlias,
+                                                                    '직급',
+                                                                  ),
+                                                                  'email':
+                                                                      currentUserEmail,
+                                                                  'phone':
+                                                                      valueOrDefault<
+                                                                          String>(
+                                                                    _model
+                                                                        .studentIdTextFieldTextController2
+                                                                        .text,
+                                                                    '',
+                                                                  ),
+                                                                  'permission_level':
+                                                                      1,
                                                                 });
                                                                 _shouldSetState =
                                                                     true;


### PR DESCRIPTION
## Summary
- align the admin sidebar icon highlight with the AdminManager route so the menu reflects the active admin account page
- harden admin-post merges to keep contact info, elevate 전임 and admin-managed accounts to master permissions, and backfill missing emails from admin IDs

## Testing
- flutter analyze *(fails: Flutter SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d3fb66a0748323b9cf718c3e609c04