### PR TITLE
Log class student roster before PDF download

### DIFF
--- a/lib/components/dashboard/dashboard_class_container/dashboard_class_container_widget.dart
+++ b/lib/components/dashboard/dashboard_class_container/dashboard_class_container_widget.dart
@@ -1,3 +1,4 @@
+import '/backend/supabase/supabase.dart';
 import '/flutter_flow/flutter_flow_theme.dart';
 import '/flutter_flow/flutter_flow_util.dart';
 import '/flutter_flow/flutter_flow_widgets.dart';
@@ -16,6 +17,9 @@ class DashboardClassContainerWidget extends StatefulWidget {
     required this.isDesign,
     String? section,
     required this.professor,
+    this.year,
+    this.semester,
+    this.grade,
     required this.getDetailClassID,
     required this.classID,
     int? currentlySelectedID,
@@ -33,6 +37,15 @@ class DashboardClassContainerWidget extends StatefulWidget {
 
   /// 교수님
   final String? professor;
+
+  /// 학년도
+  final String? year;
+
+  /// 학기
+  final String? semester;
+
+  /// 학년
+  final int? grade;
 
   /// 수업 진행사항 컴포넌트에 필요한 정보를 읽어오고 'displayClassDetail'과 같은 boolean을 토대로 화면에 띄울지
   /// 말지 결정
@@ -405,6 +418,30 @@ class _DashboardClassContainerWidgetState
                           try {
                             final classId =
                                 widget.classID ?? FFAppState().classSelectedID;
+
+                            if (classId <= 0) {
+                              debugPrint(
+                                  '[DashboardClassContainerWidget] 유효하지 않은 클래스 ID: $classId');
+                            } else {
+                              final fetchedStudents =
+                                  await actions.fetchClassStudents(
+                                classId: classId,
+                                year: widget.year,
+                                semester: widget.semester,
+                                grade: widget.grade,
+                                courseName: widget.courseName,
+                                professorName: widget.professor,
+                                section: widget.section,
+                              );
+
+                              final studentNames = fetchedStudents
+                                  .map((student) => student.studentName ?? '이름 없음')
+                                  .join(', ');
+
+                              debugPrint(
+                                  '[DashboardClassContainerWidget] 선택된 수업 학생 (${fetchedStudents.length}명): $studentNames');
+                            }
+
                             final documentUrls = await actions
                                 .getClassDocuments(classId);
 

--- a/lib/custom_code/actions/fetch_class_students.dart
+++ b/lib/custom_code/actions/fetch_class_students.dart
@@ -1,0 +1,84 @@
+// Automatic FlutterFlow imports
+import '/backend/schema/structs/index.dart';
+import '/backend/schema/enums/enums.dart';
+import '/backend/supabase/supabase.dart';
+import '/flutter_flow/flutter_flow_theme.dart';
+import '/flutter_flow/flutter_flow_util.dart';
+import 'index.dart'; // Imports other custom actions
+import 'package:flutter/material.dart';
+// Begin custom action code
+// DO NOT REMOVE OR MODIFY THE CODE ABOVE!
+
+Future<List<CourseStudentRow>> fetchClassStudents({
+  int? classId,
+  String? year,
+  String? semester,
+  int? grade,
+  String? courseName,
+  String? professorName,
+  String? section,
+}) async {
+  if (classId == null || classId <= 0) {
+    debugPrint('[fetchClassStudents] 잘못된 classId: $classId');
+    return [];
+  }
+
+  String? _clean(String? value) {
+    final trimmed = value?.trim();
+    if (trimmed == null || trimmed.isEmpty) {
+      return null;
+    }
+    return trimmed;
+  }
+
+  final normalizedYear = _clean(year);
+  final normalizedSemester = _clean(semester);
+  final normalizedCourse = _clean(courseName);
+  final normalizedProfessor = _clean(professorName);
+  final normalizedSection = _clean(section);
+
+  List<CourseStudentRow> results = [];
+
+  try {
+    results = await CourseStudentTable().queryRows(
+      queryFn: (q) {
+        var query = q.eq('classid', classId);
+
+        if (normalizedYear != null) {
+          query = query.eqOrNull('year', normalizedYear);
+        }
+        if (normalizedSemester != null) {
+          query = query.eqOrNull('semester', normalizedSemester);
+        }
+        if (grade != null && grade > 0) {
+          query = query.eqOrNull('grade', grade);
+        }
+        if (normalizedCourse != null) {
+          query = query.eqOrNull('course_name', normalizedCourse);
+        }
+        if (normalizedProfessor != null) {
+          query = query.eqOrNull('professor_name', normalizedProfessor);
+        }
+        if (normalizedSection != null) {
+          query = query.eqOrNull('section_type', normalizedSection);
+        }
+
+        return query.order('student_name');
+      },
+    );
+  } catch (error) {
+    debugPrint('[fetchClassStudents] 학생 목록 조회 실패: $error');
+    return [];
+  }
+
+  debugPrint(
+      '[fetchClassStudents] 선택 정보 => classId: $classId, year: ${normalizedYear ?? '-'}, semester: ${normalizedSemester ?? '-'}, grade: ${grade ?? '-'}, course: ${normalizedCourse ?? '-'}, professor: ${normalizedProfessor ?? '-'}, section: ${normalizedSection ?? '-'}');
+  debugPrint('[fetchClassStudents] 조회된 학생 수: ${results.length}');
+  for (final student in results) {
+    final name = student.studentName ?? '이름 없음';
+    final studentId = student.studentId?.toString() ?? 'ID 없음';
+    debugPrint('  · 학생: $name (ID: $studentId)');
+  }
+
+  return results;
+}

--- a/lib/custom_code/actions/index.dart
+++ b/lib/custom_code/actions/index.dart
@@ -3,5 +3,6 @@ export 'merge_and_download_pdf.dart' show mergeAndDownloadPdf;
 export 'start_download_action.dart' show startDownloadAction;
 export 'debug_printing.dart' show debugPrinting;
 export 'fail_debug.dart' show failDebug;
+export 'fetch_class_students.dart' show fetchClassStudents;
 export 'get_class_documents.dart' show getClassDocuments;
 export 'search_posts.dart' show searchPosts;

--- a/lib/pages/admin/dashboard/admin_dash/admin_dash_widget.dart
+++ b/lib/pages/admin/dashboard/admin_dash/admin_dash_widget.dart
@@ -2117,6 +2117,9 @@ class _AdminDashWidgetState extends State<AdminDashWidget> {
                                                                                   visibleClassItem.professor,
                                                                                   '이름',
                                                                                 ),
+                                                                                year: visibleClassItem.year,
+                                                                                semester: visibleClassItem.semester,
+                                                                                grade: visibleClassItem.grade,
                                                                                 classID: visibleClassItem.id,
                                                                                 currentlySelectedID: _model.selectedClassDetailID,
                                                                                 getDetailClassID: (displayClassDetailID) async {
@@ -2280,6 +2283,9 @@ class _AdminDashWidgetState extends State<AdminDashWidget> {
                                                                                 searchedResultsItem.section,
                                                                             professor:
                                                                                 searchedResultsItem.professor!,
+                                                                            year: searchedResultsItem.year,
+                                                                            semester: searchedResultsItem.semester,
+                                                                            grade: searchedResultsItem.grade,
                                                                             classID:
                                                                                 searchedResultsItem.id,
                                                                             currentlySelectedID:

--- a/lib/pages/admin/submissions/admin_portfolio/admin_portfolio_widget.dart
+++ b/lib/pages/admin/submissions/admin_portfolio/admin_portfolio_widget.dart
@@ -2276,6 +2276,9 @@ class _AdminPortfolioWidgetState extends State<AdminPortfolioWidget> {
                                                                                 searchedResultsItem.section,
                                                                             professor:
                                                                                 searchedResultsItem.professor!,
+                                                                            year: searchedResultsItem.year,
+                                                                            semester: searchedResultsItem.semester,
+                                                                            grade: searchedResultsItem.grade,
                                                                             classID:
                                                                                 searchedResultsItem.id,
                                                                             currentlySelectedID:


### PR DESCRIPTION
## Summary
- add a custom action to retrieve students for a selected class using year, semester, grade, subject, professor, and section filters
- wire the dashboard class container PDF download flow to fetch students and log the roster before merging PDFs
- pass year, semester, and grade data into the dashboard class container from admin dashboards so the action has full context

## Testing
- Not run (Flutter SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d7ac00e05c8323a2faebaeb7b43e27