### PR TITLE
Refine professor profile layout

### DIFF
--- a/lib/flutter_flow/internationalization.dart
+++ b/lib/flutter_flow/internationalization.dart
@@ -8821,6 +8821,26 @@ final kTranslationsMap = <Map<String, Map<String, String>>>[
       'ko': '기타 전문분야',
       'en': '',
     },
+    'vy01bq1t': {
+      'ko': '[항목 관리]',
+      'en': '[Manage Items]',
+    },
+    'nt4t0nqj': {
+      'ko': '[작성 가이드]',
+      'en': '[Writing Guide]',
+    },
+    'k3syibn2': {
+      'ko': '• 500자 이내로 작성해주세요.',
+      'en': '• Please keep within 500 characters.',
+    },
+    'xj0z9d34': {
+      'ko': '• 최신 순으로 핵심 성과를 정리해주세요.',
+      'en': '• Outline key achievements in reverse chronological order.',
+    },
+    'vwgfg9ii': {
+      'ko': '현재 글자 수',
+      'en': 'Current characters',
+    },
     'ib59489c': {
       'ko': '[학력 설정]',
       'en': '',

--- a/lib/pages/professor/profile/prof_my_profile/prof_my_profile_widget.dart
+++ b/lib/pages/professor/profile/prof_my_profile/prof_my_profile_widget.dart
@@ -612,7 +612,90 @@ class _ProfMyProfileWidgetState extends State<ProfMyProfileWidget> {
       );
     }
 
-    Widget _buildRecordActionRow({
+    Widget _buildSectionContainer({
+      required BuildContext context,
+      required Widget leftChild,
+      Widget? rightChild,
+    }) {
+      final theme = FlutterFlowTheme.of(context);
+      return Container(
+        decoration: BoxDecoration(
+          color: theme.primaryBackground,
+          borderRadius: BorderRadius.circular(16.0),
+          border: Border.all(
+            color: theme.alternate,
+            width: 1.0,
+          ),
+        ),
+        padding: const EdgeInsets.all(12.0),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Expanded(
+              flex: 7,
+              child: leftChild,
+            ),
+            if (rightChild != null) ...[
+              const SizedBox(width: 16.0),
+              Expanded(
+                flex: 3,
+                child: rightChild!,
+              ),
+            ],
+          ],
+        ),
+      );
+    }
+
+    Widget _buildActionButton({
+      required BuildContext context,
+      required VoidCallback onPressed,
+      required String label,
+      required IconData icon,
+      required Color backgroundColor,
+      Color? borderColor,
+      Color iconColor = Colors.white,
+    }) {
+      final theme = FlutterFlowTheme.of(context);
+      return FFButtonWidget(
+        onPressed: onPressed,
+        text: label,
+        icon: Icon(
+          icon,
+          size: 18.0,
+        ),
+        options: FFButtonOptions(
+          height: _recordButtonHeight(context),
+          padding: const EdgeInsetsDirectional.fromSTEB(
+            16.0,
+            0.0,
+            16.0,
+            0.0,
+          ),
+          iconPadding: EdgeInsetsDirectional.zero,
+          iconColor: iconColor,
+          color: backgroundColor,
+          textStyle: theme.titleSmall.override(
+            font: GoogleFonts.openSans(
+              fontWeight: theme.titleSmall.fontWeight,
+              fontStyle: theme.titleSmall.fontStyle,
+            ),
+            color: Colors.white,
+            fontSize: _recordButtonFontSize(context),
+            letterSpacing: 0.0,
+            fontWeight: theme.titleSmall.fontWeight,
+            fontStyle: theme.titleSmall.fontStyle,
+          ),
+          elevation: 0.0,
+          borderSide: borderColor != null
+              ? BorderSide(color: borderColor)
+              : const BorderSide(color: Colors.transparent),
+          borderRadius: BorderRadius.circular(8.0),
+        ),
+      );
+    }
+
+    Widget _buildRecordActionPanel({
       required BuildContext context,
       required bool canAdd,
       required VoidCallback onAdd,
@@ -622,96 +705,138 @@ class _ProfMyProfileWidgetState extends State<ProfMyProfileWidget> {
       required String removeLabel,
     }) {
       final theme = FlutterFlowTheme.of(context);
-      if (!canAdd && !canRemove) {
+      final actionWidgets = <Widget>[];
+
+      if (canAdd) {
+        actionWidgets.add(
+          _buildActionButton(
+            context: context,
+            onPressed: onAdd,
+            label: addLabel,
+            icon: Icons.add_to_photos_outlined,
+            backgroundColor: const Color(0xFFA6B6C3),
+            iconColor: theme.primaryBackground,
+          ),
+        );
+      }
+
+      if (canAdd && canRemove) {
+        actionWidgets.add(const SizedBox(height: 12.0));
+      }
+
+      if (canRemove) {
+        actionWidgets.add(
+          _buildActionButton(
+            context: context,
+            onPressed: onRemove,
+            label: removeLabel,
+            icon: Icons.delete_forever,
+            backgroundColor: theme.secondaryText,
+            borderColor: theme.secondaryText,
+            iconColor: theme.primaryBackground,
+          ),
+        );
+      }
+
+      if (actionWidgets.isEmpty) {
         return const SizedBox.shrink();
       }
+
       return Container(
-        color: theme.primaryBackground,
-        padding: const EdgeInsetsDirectional.fromSTEB(5.0, 0.0, 5.0, 0.0),
-        child: Row(
+        decoration: BoxDecoration(
+          color: theme.secondaryBackground,
+          borderRadius: BorderRadius.circular(12.0),
+        ),
+        padding: const EdgeInsets.all(12.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: actionWidgets,
+        ),
+      );
+    }
+
+    Widget _buildSectionSidePanel({
+      required BuildContext context,
+      required String title,
+      required Widget child,
+    }) {
+      final theme = FlutterFlowTheme.of(context);
+      return Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Text(
+            title,
+            style: theme.titleSmall.override(
+              font: GoogleFonts.openSans(
+                fontWeight: theme.titleSmall.fontWeight,
+                fontStyle: theme.titleSmall.fontStyle,
+              ),
+              fontSize: _recordButtonFontSize(context),
+              letterSpacing: 0.0,
+              fontWeight: FontWeight.w600,
+              fontStyle: theme.titleSmall.fontStyle,
+            ),
+          ),
+          const SizedBox(height: 12.0),
+          child,
+        ],
+      );
+    }
+
+    Widget _buildProjectGuidePanel({
+      required BuildContext context,
+      required int charCount,
+    }) {
+      final theme = FlutterFlowTheme.of(context);
+      return Container(
+        decoration: BoxDecoration(
+          color: theme.secondaryBackground,
+          borderRadius: BorderRadius.circular(12.0),
+        ),
+        padding: const EdgeInsets.all(12.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            if (canAdd)
-              FFButtonWidget(
-                onPressed: onAdd,
-                text: addLabel,
-                icon: const Icon(
-                  Icons.add_to_photos_outlined,
-                  size: 15.0,
+            Text(
+              FFLocalizations.of(context)
+                  .getText('k3syibn2' /* • 500자 이내로 작성해주세요. */),
+              style: theme.labelMedium.override(
+                font: GoogleFonts.openSans(
+                  fontWeight: theme.labelMedium.fontWeight,
+                  fontStyle: theme.labelMedium.fontStyle,
                 ),
-                options: FFButtonOptions(
-                  height: _recordButtonHeight(context),
-                  padding: const EdgeInsetsDirectional.fromSTEB(
-                    16.0,
-                    0.0,
-                    16.0,
-                    0.0,
-                  ),
-                  iconPadding: const EdgeInsetsDirectional.fromSTEB(
-                    0.0,
-                    0.0,
-                    0.0,
-                    0.0,
-                  ),
-                  iconColor: theme.primaryBackground,
-                  color: const Color(0xFFA6B6C3),
-                  textStyle: theme.titleSmall.override(
-                    font: GoogleFonts.openSans(
-                      fontWeight: theme.titleSmall.fontWeight,
-                      fontStyle: theme.titleSmall.fontStyle,
-                    ),
-                    color: Colors.white,
-                    fontSize: _recordButtonFontSize(context),
-                    letterSpacing: 0.0,
-                    fontWeight: theme.titleSmall.fontWeight,
-                    fontStyle: theme.titleSmall.fontStyle,
-                  ),
-                  elevation: 0.0,
-                  borderRadius: BorderRadius.circular(8.0),
-                ),
+                letterSpacing: 0.0,
+                fontWeight: theme.labelMedium.fontWeight,
+                fontStyle: theme.labelMedium.fontStyle,
               ),
+            ),
+            const SizedBox(height: 8.0),
+            Text(
+              FFLocalizations.of(context)
+                  .getText('xj0z9d34' /* • 최신 순으로 핵심 성과를 정리해주세요. */),
+              style: theme.labelMedium.override(
+                font: GoogleFonts.openSans(
+                  fontWeight: theme.labelMedium.fontWeight,
+                  fontStyle: theme.labelMedium.fontStyle,
+                ),
+                letterSpacing: 0.0,
+                fontWeight: theme.labelMedium.fontWeight,
+                fontStyle: theme.labelMedium.fontStyle,
+              ),
+            ),
             const Spacer(),
-            if (canRemove)
-              FFButtonWidget(
-                onPressed: onRemove,
-                text: removeLabel,
-                icon: const Icon(
-                  Icons.delete_forever,
-                  size: 15.0,
+            Text(
+              '${FFLocalizations.of(context).getText('vwgfg9ii' /* 현재 글자 수 */)}: $charCount / 500',
+              style: theme.bodySmall.override(
+                font: GoogleFonts.openSans(
+                  fontWeight: theme.bodySmall.fontWeight,
+                  fontStyle: theme.bodySmall.fontStyle,
                 ),
-                options: FFButtonOptions(
-                  height: _recordButtonHeight(context),
-                  padding: const EdgeInsetsDirectional.fromSTEB(
-                    16.0,
-                    0.0,
-                    16.0,
-                    0.0,
-                  ),
-                  iconPadding: const EdgeInsetsDirectional.fromSTEB(
-                    0.0,
-                    0.0,
-                    0.0,
-                    0.0,
-                  ),
-                  iconColor: theme.primaryBackground,
-                  color: theme.secondaryText,
-                  textStyle: theme.titleSmall.override(
-                    font: GoogleFonts.openSans(
-                      fontWeight: theme.titleSmall.fontWeight,
-                      fontStyle: theme.titleSmall.fontStyle,
-                    ),
-                    color: Colors.white,
-                    fontSize: _recordButtonFontSize(context),
-                    letterSpacing: 0.0,
-                    fontWeight: theme.titleSmall.fontWeight,
-                    fontStyle: theme.titleSmall.fontStyle,
-                  ),
-                  elevation: 0.0,
-                  borderSide: BorderSide(
-                    color: theme.secondaryText,
-                  ),
-                  borderRadius: BorderRadius.circular(8.0),
-                ),
+                letterSpacing: 0.0,
+                fontWeight: FontWeight.w600,
+                fontStyle: theme.bodySmall.fontStyle,
               ),
+            ),
           ],
         ),
       );
@@ -816,11 +941,9 @@ class _ProfMyProfileWidgetState extends State<ProfMyProfileWidget> {
                 5.0,
                 8.0,
               ),
-              child: Container(
-                decoration: BoxDecoration(
-                  color: FlutterFlowTheme.of(context).primaryBackground,
-                ),
-                child: Column(
+              child: _buildSectionContainer(
+                context: context,
+                leftChild: Column(
                   crossAxisAlignment: CrossAxisAlignment.stretch,
                   children: [
                     _buildRecordHeaderRow(
@@ -832,7 +955,7 @@ class _ProfMyProfileWidgetState extends State<ProfMyProfileWidget> {
                         '학위',
                       ],
                     ),
-                    const SizedBox(height: 8.0),
+                    const SizedBox(height: 12.0),
                     Expanded(
                       child: SingleChildScrollView(
                         child: Column(
@@ -869,11 +992,11 @@ class _ProfMyProfileWidgetState extends State<ProfMyProfileWidget> {
                                   Expanded(
                                     child: TextFormField(
                                       controller: _model
-                                              .academicUniversityTextControllers[
-                                          academicIndex],
+                                          .academicUniversityTextControllers[
+                                              academicIndex],
                                       focusNode: _model
-                                              .academicUniversityFocusNodes[
-                                          academicIndex],
+                                          .academicUniversityFocusNodes[
+                                              academicIndex],
                                       decoration: _recordInputDecoration(
                                         context,
                                         'OO대학교',
@@ -889,15 +1012,15 @@ class _ProfMyProfileWidgetState extends State<ProfMyProfileWidget> {
                                   const SizedBox(width: 8.0),
                                   Expanded(
                                     child: TextFormField(
-                                      controller: _model
-                                              .academicMajorTextControllers[
-                                          academicIndex],
-                                      focusNode: _model
-                                              .academicMajorFocusNodes[
-                                          academicIndex],
+                                      controller:
+                                          _model.academicMajorTextControllers[
+                                              academicIndex],
+                                      focusNode:
+                                          _model.academicMajorFocusNodes[
+                                              academicIndex],
                                       decoration: _recordInputDecoration(
                                         context,
-                                        '건축학과',
+                                        '전공',
                                       ),
                                       style: _recordTextStyle(context),
                                       onChanged: (_) =>
@@ -910,15 +1033,15 @@ class _ProfMyProfileWidgetState extends State<ProfMyProfileWidget> {
                                   const SizedBox(width: 8.0),
                                   Expanded(
                                     child: TextFormField(
-                                      controller: _model
-                                              .academicDegreeTextControllers[
-                                          academicIndex],
-                                      focusNode: _model
-                                              .academicDegreeFocusNodes[
-                                          academicIndex],
+                                      controller:
+                                          _model.academicDegreeTextControllers[
+                                              academicIndex],
+                                      focusNode:
+                                          _model.academicDegreeFocusNodes[
+                                              academicIndex],
                                       decoration: _recordInputDecoration(
                                         context,
-                                        '학위',
+                                        '석사/박사',
                                       ),
                                       style: _recordTextStyle(context),
                                       onChanged: (_) =>
@@ -934,9 +1057,13 @@ class _ProfMyProfileWidgetState extends State<ProfMyProfileWidget> {
                           ),
                         ),
                       ),
-                    ),
-                    const SizedBox(height: 8.0),
-                    _buildRecordActionRow(
+                    ],
+                  ),
+                  rightChild: _buildSectionSidePanel(
+                    context: context,
+                    title: FFLocalizations.of(context)
+                        .getText('vy01bq1t' /* [항목 관리] */),
+                    child: _buildRecordActionPanel(
                       context: context,
                       canAdd: _model.academicRecords.length < 3,
                       onAdd: () async {
@@ -985,15 +1112,13 @@ class _ProfMyProfileWidgetState extends State<ProfMyProfileWidget> {
                       removeLabel: FFLocalizations.of(context)
                           .getText('adyemods' /* 삭제 - */),
                     ),
-                  ],
+                  ),
                 ),
               ),
             ),
-          ),
-        ],
-      );
-    }
-
+          ],
+        );
+      }
     Widget _buildTeachingSection(BuildContext context) {
       final recordCount = _model.teachingPeriodTextControllers.length;
       return Column(
@@ -1012,11 +1137,9 @@ class _ProfMyProfileWidgetState extends State<ProfMyProfileWidget> {
                 5.0,
                 8.0,
               ),
-              child: Container(
-                decoration: BoxDecoration(
-                  color: FlutterFlowTheme.of(context).primaryBackground,
-                ),
-                child: Column(
+              child: _buildSectionContainer(
+                context: context,
+                leftChild: Column(
                   crossAxisAlignment: CrossAxisAlignment.stretch,
                   children: [
                     _buildRecordHeaderRow(
@@ -1028,7 +1151,7 @@ class _ProfMyProfileWidgetState extends State<ProfMyProfileWidget> {
                         '학점/시간',
                       ],
                     ),
-                    const SizedBox(height: 8.0),
+                    const SizedBox(height: 12.0),
                     Expanded(
                       child: SingleChildScrollView(
                         child: Column(
@@ -1043,11 +1166,11 @@ class _ProfMyProfileWidgetState extends State<ProfMyProfileWidget> {
                                   Expanded(
                                     child: TextFormField(
                                       controller: _model
-                                              .teachingPeriodTextControllers[
-                                          teachingIndex],
+                                          .teachingPeriodTextControllers[
+                                              teachingIndex],
                                       focusNode: _model
-                                              .teachingPeriodFocusNodes[
-                                          teachingIndex],
+                                          .teachingPeriodFocusNodes[
+                                              teachingIndex],
                                       decoration: _recordInputDecoration(
                                         context,
                                         '기간',
@@ -1064,11 +1187,11 @@ class _ProfMyProfileWidgetState extends State<ProfMyProfileWidget> {
                                   Expanded(
                                     child: TextFormField(
                                       controller: _model
-                                              .teachingSchoolTextControllers[
-                                          teachingIndex],
+                                          .teachingSchoolTextControllers[
+                                              teachingIndex],
                                       focusNode: _model
-                                              .teachingSchoolFocusNodes[
-                                          teachingIndex],
+                                          .teachingSchoolFocusNodes[
+                                              teachingIndex],
                                       decoration: _recordInputDecoration(
                                         context,
                                         'OO대학교/OO과',
@@ -1085,11 +1208,11 @@ class _ProfMyProfileWidgetState extends State<ProfMyProfileWidget> {
                                   Expanded(
                                     child: TextFormField(
                                       controller: _model
-                                              .teachingSubjectTextControllers[
-                                          teachingIndex],
+                                          .teachingSubjectTextControllers[
+                                              teachingIndex],
                                       focusNode: _model
-                                              .teachingSubjectFocusNodes[
-                                          teachingIndex],
+                                          .teachingSubjectFocusNodes[
+                                              teachingIndex],
                                       decoration: _recordInputDecoration(
                                         context,
                                         '강의과목',
@@ -1106,11 +1229,11 @@ class _ProfMyProfileWidgetState extends State<ProfMyProfileWidget> {
                                   Expanded(
                                     child: TextFormField(
                                       controller: _model
-                                              .teachingCreditTextControllers[
-                                          teachingIndex],
+                                          .teachingCreditTextControllers[
+                                              teachingIndex],
                                       focusNode: _model
-                                              .teachingCreditFocusNodes[
-                                          teachingIndex],
+                                          .teachingCreditFocusNodes[
+                                              teachingIndex],
                                       decoration: _recordInputDecoration(
                                         context,
                                         '학점/시간',
@@ -1129,9 +1252,13 @@ class _ProfMyProfileWidgetState extends State<ProfMyProfileWidget> {
                           ),
                         ),
                       ),
-                    ),
-                    const SizedBox(height: 8.0),
-                    _buildRecordActionRow(
+                    ],
+                  ),
+                  rightChild: _buildSectionSidePanel(
+                    context: context,
+                    title: FFLocalizations.of(context)
+                        .getText('vy01bq1t' /* [항목 관리] */),
+                    child: _buildRecordActionPanel(
                       context: context,
                       canAdd: _model.teachingRecords.length < 4,
                       onAdd: () async {
@@ -1180,17 +1307,18 @@ class _ProfMyProfileWidgetState extends State<ProfMyProfileWidget> {
                       removeLabel: FFLocalizations.of(context)
                           .getText('d31dksav' /* 삭제 - */),
                     ),
-                  ],
+                  ),
                 ),
               ),
             ),
-          ),
         ],
       );
     }
-
+    
     Widget _buildProjectSection(BuildContext context) {
       final theme = FlutterFlowTheme.of(context);
+      final charCount =
+          _model.projectTextFieldTextController?.text.length ?? 0;
       return Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
@@ -1208,107 +1336,120 @@ class _ProfMyProfileWidgetState extends State<ProfMyProfileWidget> {
                 5.0,
                 8.0,
               ),
-              child: SafeArea(
-                child: Container(
-                  decoration: BoxDecoration(
-                    color: theme.primaryBackground,
-                  ),
-                  child: TextFormField(
-                    controller: _model.projectTextFieldTextController,
-                    focusNode: _model.projectTextFieldFocusNode,
-                    autofocus: true,
-                    obscureText: false,
-                    decoration: InputDecoration(
-                      isDense: true,
-                      labelStyle: theme.labelMedium.override(
-                        font: GoogleFonts.openSans(
-                          fontWeight: theme.labelMedium.fontWeight,
-                          fontStyle: theme.labelMedium.fontStyle,
+              child: _buildSectionContainer(
+                context: context,
+                leftChild: Column(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    Expanded(
+                      child: TextFormField(
+                        controller: _model.projectTextFieldTextController,
+                        focusNode: _model.projectTextFieldFocusNode,
+                        autofocus: false,
+                        obscureText: false,
+                        decoration: InputDecoration(
+                          isDense: true,
+                          labelStyle: theme.labelMedium.override(
+                            font: GoogleFonts.openSans(
+                              fontWeight: theme.labelMedium.fontWeight,
+                              fontStyle: theme.labelMedium.fontStyle,
+                            ),
+                            letterSpacing: 0.0,
+                            fontWeight: theme.labelMedium.fontWeight,
+                            fontStyle: theme.labelMedium.fontStyle,
+                          ),
+                          hintText: FFLocalizations.of(context)
+                              .getText('bbx9df2u' /* 논문. 프로젝트 등 경력사항 */),
+                          hintStyle: theme.labelMedium.override(
+                            font: GoogleFonts.openSans(
+                              fontWeight: theme.labelMedium.fontWeight,
+                              fontStyle: theme.labelMedium.fontStyle,
+                            ),
+                            fontSize: () {
+                              final width = MediaQuery.sizeOf(context).width;
+                              if (width < kBreakpointSmall) {
+                                return 6.0;
+                              } else if (width < kBreakpointMedium) {
+                                return 8.0;
+                              } else if (width < kBreakpointLarge) {
+                                return 10.0;
+                              }
+                              return 12.0;
+                            }(),
+                            letterSpacing: 0.0,
+                            fontWeight: theme.labelMedium.fontWeight,
+                            fontStyle: theme.labelMedium.fontStyle,
+                          ),
+                          enabledBorder: OutlineInputBorder(
+                            borderSide: const BorderSide(
+                              color: Color(0x00000000),
+                              width: 1.0,
+                            ),
+                            borderRadius: BorderRadius.circular(8.0),
+                          ),
+                          focusedBorder: OutlineInputBorder(
+                            borderSide: const BorderSide(
+                              color: Color(0x00000000),
+                              width: 1.0,
+                            ),
+                            borderRadius: BorderRadius.circular(8.0),
+                          ),
+                          errorBorder: OutlineInputBorder(
+                            borderSide: BorderSide(
+                              color: theme.error,
+                              width: 1.0,
+                            ),
+                            borderRadius: BorderRadius.circular(8.0),
+                          ),
+                          focusedErrorBorder: OutlineInputBorder(
+                            borderSide: BorderSide(
+                              color: theme.error,
+                              width: 1.0,
+                            ),
+                            borderRadius: BorderRadius.circular(8.0),
+                          ),
+                          filled: true,
+                          fillColor: theme.secondaryBackground,
                         ),
-                        letterSpacing: 0.0,
-                        fontWeight: theme.labelMedium.fontWeight,
-                        fontStyle: theme.labelMedium.fontStyle,
-                      ),
-                      hintText: FFLocalizations.of(context)
-                          .getText('bbx9df2u' /* 논문. 프로젝트 등 경력사항 */),
-                      hintStyle: theme.labelMedium.override(
-                        font: GoogleFonts.openSans(
-                          fontWeight: theme.labelMedium.fontWeight,
-                          fontStyle: theme.labelMedium.fontStyle,
+                        style: theme.bodyMedium.override(
+                          font: GoogleFonts.openSans(
+                            fontWeight: theme.bodyMedium.fontWeight,
+                            fontStyle: theme.bodyMedium.fontStyle,
+                          ),
+                          fontSize: () {
+                            final width = MediaQuery.sizeOf(context).width;
+                            if (width < kBreakpointSmall) {
+                              return 6.0;
+                            } else if (width < kBreakpointMedium) {
+                              return 8.0;
+                            } else if (width < kBreakpointLarge) {
+                              return 10.0;
+                            }
+                            return 12.0;
+                          }(),
+                          letterSpacing: 0.0,
+                          fontWeight: theme.bodyMedium.fontWeight,
+                          fontStyle: theme.bodyMedium.fontStyle,
                         ),
-                        fontSize: () {
-                          final width = MediaQuery.sizeOf(context).width;
-                          if (width < kBreakpointSmall) {
-                            return 6.0;
-                          } else if (width < kBreakpointMedium) {
-                            return 8.0;
-                          } else if (width < kBreakpointLarge) {
-                            return 10.0;
-                          }
-                          return 12.0;
-                        }(),
-                        letterSpacing: 0.0,
-                        fontWeight: theme.labelMedium.fontWeight,
-                        fontStyle: theme.labelMedium.fontStyle,
+                        maxLines: null,
+                        minLines: 8,
+                        maxLength: 500,
+                        maxLengthEnforcement: MaxLengthEnforcement.enforced,
+                        cursorColor: theme.primaryText,
+                        onChanged: (_) => safeSetState(() {}),
+                        validator: _model.projectTextFieldTextControllerValidator
+                            .asValidator(context),
                       ),
-                      enabledBorder: OutlineInputBorder(
-                        borderSide: const BorderSide(
-                          color: Color(0x00000000),
-                          width: 1.0,
-                        ),
-                        borderRadius: BorderRadius.circular(8.0),
-                      ),
-                      focusedBorder: OutlineInputBorder(
-                        borderSide: const BorderSide(
-                          color: Color(0x00000000),
-                          width: 1.0,
-                        ),
-                        borderRadius: BorderRadius.circular(8.0),
-                      ),
-                      errorBorder: OutlineInputBorder(
-                        borderSide: BorderSide(
-                          color: theme.error,
-                          width: 1.0,
-                        ),
-                        borderRadius: BorderRadius.circular(8.0),
-                      ),
-                      focusedErrorBorder: OutlineInputBorder(
-                        borderSide: BorderSide(
-                          color: theme.error,
-                          width: 1.0,
-                        ),
-                        borderRadius: BorderRadius.circular(8.0),
-                      ),
-                      filled: true,
-                      fillColor: theme.secondaryBackground,
                     ),
-                    style: theme.bodyMedium.override(
-                      font: GoogleFonts.openSans(
-                        fontWeight: theme.bodyMedium.fontWeight,
-                        fontStyle: theme.bodyMedium.fontStyle,
-                      ),
-                      fontSize: () {
-                        final width = MediaQuery.sizeOf(context).width;
-                        if (width < kBreakpointSmall) {
-                          return 6.0;
-                        } else if (width < kBreakpointMedium) {
-                          return 8.0;
-                        } else if (width < kBreakpointLarge) {
-                          return 10.0;
-                        }
-                        return 12.0;
-                      }(),
-                      letterSpacing: 0.0,
-                      fontWeight: theme.bodyMedium.fontWeight,
-                      fontStyle: theme.bodyMedium.fontStyle,
-                    ),
-                    maxLines: null,
-                    minLines: 8,
-                    maxLength: 500,
-                    maxLengthEnforcement: MaxLengthEnforcement.enforced,
-                    cursorColor: theme.primaryText,
-                    validator: _model.projectTextFieldTextControllerValidator
-                        .asValidator(context),
+                  ],
+                ),
+                rightChild: _buildSectionSidePanel(
+                  context: context,
+                  title: FFLocalizations.of(context)
+                      .getText('nt4t0nqj' /* [작성 가이드] */),
+                  child: _buildProjectGuidePanel(
+                    context: context,
+                    charCount: charCount,
                   ),
                 ),
               ),
@@ -1317,7 +1458,6 @@ class _ProfMyProfileWidgetState extends State<ProfMyProfileWidget> {
         ],
       );
     }
-
   List<Map<String, dynamic>> _collectAcademicRecords() {
     final records = <Map<String, dynamic>>[];
     for (var i = 0; i < _model.academicGetDateTextControllers.length; i++) {


### PR DESCRIPTION
## Summary
- introduce reusable section container and action panel helpers for the professor profile
- redesign the academic, teaching, and project sections with a consistent 70/30 split and shared styling
- add a project writing guide side panel and supporting localization strings

## Testing
- flutter analyze *(fails: flutter not installed in container)*
- dart format *(fails: dart not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d7ac7918188323a8f49a74b4fc9c00